### PR TITLE
Clean up Converters

### DIFF
--- a/lib/src/fake_converted_query.dart
+++ b/lib/src/fake_converted_query.dart
@@ -1,0 +1,33 @@
+// ignore: subtype_of_sealed_class
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'converter.dart';
+import 'mock_query_snapshot.dart';
+
+// ignore: subtype_of_sealed_class
+/// A converted query. It should always be the last query in the chain, so we
+/// don't need to implement where, startAt, ..., withConverter.
+class FakeConvertedQuery<T extends Object?> implements Query<T> {
+  final Query<Map<String, dynamic>>? _nonConvertedParentQuery;
+
+  final Converter<T> _converter;
+
+  FakeConvertedQuery(this._nonConvertedParentQuery, this._converter);
+
+  @override
+  Future<QuerySnapshot<T>> get([GetOptions? options]) async {
+    // Converted query. It's parent contained Map<String, dynamic>.
+    final docs = (await _nonConvertedParentQuery!.get()).docs;
+    final convertedSnapshots = docs
+        .map((d) => d.reference
+            .withConverter<T>(
+                fromFirestore: _converter.fromFirestore,
+                toFirestore: _converter.toFirestore)
+            .get())
+        .toList();
+    return MockQuerySnapshot(await Future.wait(convertedSnapshots), _converter);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/lib/src/fake_converted_query.dart
+++ b/lib/src/fake_converted_query.dart
@@ -8,16 +8,15 @@ import 'mock_query_snapshot.dart';
 /// A converted query. It should always be the last query in the chain, so we
 /// don't need to implement where, startAt, ..., withConverter.
 class FakeConvertedQuery<T extends Object?> implements Query<T> {
-  final Query<Map<String, dynamic>>? _nonConvertedParentQuery;
-
+  final Query<Map<String, dynamic>> _nonConvertedParentQuery;
   final Converter<T> _converter;
 
   FakeConvertedQuery(this._nonConvertedParentQuery, this._converter);
 
   @override
   Future<QuerySnapshot<T>> get([GetOptions? options]) async {
-    // Converted query. It's parent contained Map<String, dynamic>.
-    final docs = (await _nonConvertedParentQuery!.get()).docs;
+    // Converted query. Its parent contains Map<String, dynamic>.
+    final docs = (await _nonConvertedParentQuery.get()).docs;
     final convertedSnapshots = docs
         .map((d) => d.reference
             .withConverter<T>(

--- a/lib/src/fake_converted_query.dart
+++ b/lib/src/fake_converted_query.dart
@@ -8,17 +8,18 @@ import 'mock_query_snapshot.dart';
 /// A converted query. It should always be the last query in the chain, so we
 /// don't need to implement where, startAt, ..., withConverter.
 class FakeConvertedQuery<T extends Object?> implements Query<T> {
-  final Query<Map<String, dynamic>> _nonConvertedParentQuery;
+  final Query _nonConvertedParentQuery;
   final Converter<T> _converter;
 
-  FakeConvertedQuery(this._nonConvertedParentQuery, this._converter);
+  FakeConvertedQuery(this._nonConvertedParentQuery, this._converter)
+      : assert(_nonConvertedParentQuery is Query<Map<String, dynamic>>,
+            'FakeConvertedQuery expects a non-converted query.');
 
   @override
   Future<QuerySnapshot<T>> get([GetOptions? options]) async {
-    // Converted query. Its parent contains Map<String, dynamic>.
-    final docs = (await _nonConvertedParentQuery.get()).docs;
-    final convertedSnapshots = docs
-        .map((d) => d.reference
+    final rawDocSnapshots = (await _nonConvertedParentQuery.get()).docs;
+    final convertedSnapshots = rawDocSnapshots
+        .map((rawDocSnapshot) => rawDocSnapshot.reference
             .withConverter<T>(
                 fromFirestore: _converter.fromFirestore,
                 toFirestore: _converter.toFirestore)

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -8,7 +8,6 @@ import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
 import 'converter.dart';
 import 'mock_collection_reference_platform.dart';
 import 'mock_document_reference.dart';
-import 'mock_document_snapshot.dart';
 import 'mock_query.dart';
 import 'mock_query_snapshot.dart';
 import 'util.dart';

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -183,7 +183,7 @@ class MockCollectionReference<T extends Object?> extends MockQuery<T>
       // Use the converter.
       await documentReference.update(_converter!.toFirestore(data, null));
     } else {
-      throw UnimplementedError();
+      throw StateError('This should never happen');
     }
 
     _firestore.saveDocument(documentReference.path);

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -179,8 +179,32 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
 
   @override
   Future<DocumentSnapshot<T>> get([GetOptions? options]) {
-    return Future.value(MockDocumentSnapshot<T>(
-        this, _id, docsData[_path], _exists(), _converter));
+    if (_converter == null) {
+      final rawSnapshot = MockDocumentSnapshot<T>(
+          this, _id, docsData[_path], null, false, _exists());
+      return Future.value(rawSnapshot);
+    }
+    // Convert the document.
+    final rawDocumentReference = MockDocumentReference<Map<String, dynamic>>(
+        _firestore,
+        _path,
+        _id,
+        root,
+        docsData,
+        rootParent,
+        snapshotStreamControllerRoot,
+        null);
+    final rawSnapshot = MockDocumentSnapshot<Map<String, dynamic>>(
+        rawDocumentReference,
+        _id,
+        docsData[_path],
+        docsData[_path]!,
+        false,
+        _exists());
+    final convertedData = _converter!.fromFirestore(rawSnapshot, null);
+    final convertedSnapshot = MockDocumentSnapshot<T>(
+        this, _id, docsData[_path], convertedData, true, _exists());
+    return Future.value(convertedSnapshot);
   }
 
   bool _exists() {

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -414,7 +414,7 @@ class MockQuery<T extends Object?> implements Query<T> {
             toFirestore,
           ));
     }
-    throw UnimplementedError('Shouldn\'t withConverter be called only once?');
+    throw StateError('Shouldn\'t withConverter be called only once?');
   }
 }
 

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -379,7 +379,7 @@ class MockQuery<T extends Object?> implements Query<T> {
   Query<R> withConverter<R>({required fromFirestore, required toFirestore}) {
     if (this is MockQuery<Map<String, dynamic>>) {
       return FakeConvertedQuery<R>(
-          this as MockQuery<Map<String, dynamic>>,
+          this,
           Converter<R>(
             fromFirestore,
             toFirestore,

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:quiver/core.dart';
 
 import 'converter.dart';
+import 'fake_converted_query.dart';
 import 'mock_query_platform.dart';
 import 'mock_query_snapshot.dart';
 
@@ -25,19 +26,8 @@ class MockQuery<T extends Object?> implements Query<T> {
   /// "orderBy". Null if this is a collection reference.
   final _QueryOperation<T>? _operation;
 
-  final MockQuery<Map<String, dynamic>>? _nonConvertedParentQuery;
-
-  final Converter<T>? _converter;
-
   MockQuery(this._parentQuery, this._operation)
-      : parameters = _parentQuery?.parameters ?? {},
-        _nonConvertedParentQuery = null,
-        _converter = null;
-
-  MockQuery.withConverter(this._nonConvertedParentQuery, this._converter)
-      : parameters = _nonConvertedParentQuery?.parameters ?? {},
-        _parentQuery = null,
-        _operation = null;
+      : parameters = _parentQuery?.parameters ?? {};
 
   @override
   final Map<String, dynamic> parameters;
@@ -52,29 +42,10 @@ class MockQuery<T extends Object?> implements Query<T> {
   Future<QuerySnapshot<T>> get([GetOptions? options]) async {
     // Collection references: parent query is null.
     // Regular queries: _parentQuery and _operation are not null.
-    // Converted queries: _nonConvertedParentQuery and _converter are not null.
-    assert(_parentQuery != null && _operation != null ||
-        _nonConvertedParentQuery != null && _converter != null);
-    if (_parentQuery != null && _operation != null) {
-      final parentQueryResult = await _parentQuery!.get(options);
-      final docs = _operation!(parentQueryResult.docs);
-      return MockQuerySnapshot<T>(docs, _converter);
-    }
-    // throw UnimplementedError();
-    // Converted query. It's parent contained Map<String, dynamic>.
-    final docs = (await _nonConvertedParentQuery!.get()).docs;
-    // final convertedSnapshots = docs
-    //     .map((d) => MockDocumentSnapshot<T>(
-    //         d.reference.withConverter(fromFirestore: _converter!.fromFirestore, toFirestore: _converter!.toFirestore), d.id, d.data(), d.exists, _converter))
-    //     .toList();
-    final convertedSnapshots = docs
-        .map((d) => d.reference
-            .withConverter<T>(
-                fromFirestore: _converter!.fromFirestore,
-                toFirestore: _converter!.toFirestore)
-            .get())
-        .toList();
-    return MockQuerySnapshot(await Future.wait(convertedSnapshots), _converter);
+    assert(_parentQuery != null && _operation != null);
+    final parentQueryResult = await _parentQuery!.get(options);
+    final docs = _operation!(parentQueryResult.docs);
+    return MockQuerySnapshot<T>(docs, null);
   }
 
   final _unorderedDeepEquality = const DeepCollectionEquality.unordered();
@@ -407,7 +378,7 @@ class MockQuery<T extends Object?> implements Query<T> {
   @override
   Query<R> withConverter<R>({required fromFirestore, required toFirestore}) {
     if (this is MockQuery<Map<String, dynamic>>) {
-      return MockQuery<R>.withConverter(
+      return FakeConvertedQuery<R>(
           this as MockQuery<Map<String, dynamic>>,
           Converter<R>(
             fromFirestore,

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -1,14 +1,14 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-import 'converter.dart';
 import 'mock_document_snapshot.dart';
 
 // ignore: subtype_of_sealed_class
 class MockQueryDocumentSnapshot<T extends Object?>
     extends MockDocumentSnapshot<T> implements QueryDocumentSnapshot<T> {
   MockQueryDocumentSnapshot(DocumentReference<T> reference, String documentId,
-      Map<String, dynamic>? document, Converter<T>? converter)
-      : super(reference, documentId, document, true, converter);
+      Map<String, dynamic>? rawDocument, T? convertedDocument, bool isConverted)
+      : super(reference, documentId, rawDocument, convertedDocument,
+            isConverted, true);
 
   @override
   bool get exists => true;

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -18,7 +18,7 @@ class MockQueryDocumentSnapshot<T extends Object?>
                 : converter.toFirestore(snapshot.data()!, null),
             snapshot.data(),
             converter != null,
-            true);
+            /* exists */ true);
 
   @override
   bool get exists => true;

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -1,14 +1,24 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import 'converter.dart';
 import 'mock_document_snapshot.dart';
 
 // ignore: subtype_of_sealed_class
+/// Takes a DocumentSnapshot, and wraps its data. The only difference with
+/// MockDocumentSnapshot is that it exists by definition.
 class MockQueryDocumentSnapshot<T extends Object?>
     extends MockDocumentSnapshot<T> implements QueryDocumentSnapshot<T> {
-  MockQueryDocumentSnapshot(DocumentReference<T> reference, String documentId,
-      Map<String, dynamic>? rawDocument, T? convertedDocument, bool isConverted)
-      : super(reference, documentId, rawDocument, convertedDocument,
-            isConverted, true);
+  MockQueryDocumentSnapshot.fromReference(
+      DocumentSnapshot<T> snapshot, Converter<T>? converter)
+      : super(
+            snapshot.reference,
+            snapshot.id,
+            converter == null
+                ? snapshot.data() as Map<String, dynamic>
+                : converter.toFirestore(snapshot.data()!, null),
+            snapshot.data(),
+            converter != null,
+            true);
 
   @override
   bool get exists => true;

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -8,7 +8,7 @@ import 'mock_document_snapshot.dart';
 /// MockDocumentSnapshot is that it exists by definition.
 class MockQueryDocumentSnapshot<T extends Object?>
     extends MockDocumentSnapshot<T> implements QueryDocumentSnapshot<T> {
-  MockQueryDocumentSnapshot.fromReference(
+  MockQueryDocumentSnapshot(
       DocumentSnapshot<T> snapshot, Converter<T>? converter)
       : super(
             snapshot.reference,

--- a/lib/src/mock_query_snapshot.dart
+++ b/lib/src/mock_query_snapshot.dart
@@ -25,24 +25,9 @@ class MockQuerySnapshot<T extends Object?> implements QuerySnapshot<T> {
   }
 
   @override
-  List<QueryDocumentSnapshot<T>> get docs => _documents.map((doc) {
-        if (_converter == null) {
-          assert(doc.data() is Map<String, dynamic>);
-          // We return a regular, non-converted Snapshot<Map<String, dynamic>>.
-          return MockQueryDocumentSnapshot(
-              doc.reference,
-              doc.id,
-              doc.data() as Map<String, dynamic>,
-              /* this could be null but the compiler will not allow it */ doc
-                  .data(),
-              false);
-        }
-        // With converter. We return a Snapshot<T>. Since we made
-        // MockDocumentSnapshot require a Map<String, dynamic>, we have to use
-        // toFirestore to convert T back into a Map.
-        return MockQueryDocumentSnapshot(doc.reference, doc.id,
-            _converter!.toFirestore(doc.data()!, null), doc.data()!, true);
-      }).toList();
+  List<QueryDocumentSnapshot<T>> get docs => _documents
+      .map((doc) => MockQueryDocumentSnapshot.fromReference(doc, _converter))
+      .toList();
 
   @override
   List<DocumentChange<T>> get docChanges => _documentChanges;

--- a/lib/src/mock_query_snapshot.dart
+++ b/lib/src/mock_query_snapshot.dart
@@ -29,14 +29,19 @@ class MockQuerySnapshot<T extends Object?> implements QuerySnapshot<T> {
         if (_converter == null) {
           assert(doc.data() is Map<String, dynamic>);
           // We return a regular, non-converted Snapshot<Map<String, dynamic>>.
-          return MockQueryDocumentSnapshot(doc.reference, doc.id,
-              doc.data() as Map<String, dynamic>, _converter);
+          return MockQueryDocumentSnapshot(
+              doc.reference,
+              doc.id,
+              doc.data() as Map<String, dynamic>,
+              /* this could be null but the compiler will not allow it */ doc
+                  .data(),
+              false);
         }
         // With converter. We return a Snapshot<T>. Since we made
         // MockDocumentSnapshot require a Map<String, dynamic>, we have to use
         // toFirestore to convert T back into a Map.
         return MockQueryDocumentSnapshot(doc.reference, doc.id,
-            _converter!.toFirestore(doc.data()!, null), _converter);
+            _converter!.toFirestore(doc.data()!, null), doc.data()!, true);
       }).toList();
 
   @override

--- a/lib/src/mock_query_snapshot.dart
+++ b/lib/src/mock_query_snapshot.dart
@@ -26,7 +26,7 @@ class MockQuerySnapshot<T extends Object?> implements QuerySnapshot<T> {
 
   @override
   List<QueryDocumentSnapshot<T>> get docs => _documents
-      .map((doc) => MockQueryDocumentSnapshot.fromReference(doc, _converter))
+      .map((doc) => MockQueryDocumentSnapshot(doc, _converter))
       .toList();
 
   @override


### PR DESCRIPTION
Tentative cleanup:

* separate regular Query and ConvertedQuery.
* move conversion from DocumentSnapshot to DocumentReference.
* move conversion from MockQuerySnapshot to MockQueryDocumentSnapshot.
* simplify MockQueryDocumentSnapshot to take only a docSnapshot and converter instead of 6 parameters.
* in CollectionReference, instead of manually creating DocumentSnapshots, use `DocumentReference.get()` to generate them.