### PR TITLE
 Add confirmation of up to 500 document limits

### DIFF
--- a/lib/src/mock_write_batch.dart
+++ b/lib/src/mock_write_batch.dart
@@ -36,7 +36,7 @@ class MockWriteBatch implements WriteBatch {
   @override
   Future<void> commit() {
      if (tasks.length > 500) {
-      throw Exception("exisit over 501 task.");
+      throw Exception("Firestore supports at most 500 tasks in a batch");
     }
     for (final task in tasks) {
       switch (task.command) {

--- a/lib/src/mock_write_batch.dart
+++ b/lib/src/mock_write_batch.dart
@@ -35,6 +35,9 @@ class MockWriteBatch implements WriteBatch {
 
   @override
   Future<void> commit() {
+     if (tasks.length > 500) {
+      throw Exception("exisit over 501 task.");
+    }
     for (final task in tasks) {
       switch (task.command) {
         case WriteCommand.setData:

--- a/test/mock_batch_test.dart
+++ b/test/mock_batch_test.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -55,3 +54,4 @@ void main() async {
     });
   });
 }
+

--- a/test/mock_batch_test.dart
+++ b/test/mock_batch_test.dart
@@ -1,73 +1,57 @@
+import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
-  TestWidgetsFlutterBinding.ensureInitialized();
-  String users = "users";
-  MockFirestoreInstance firestore = MockFirestoreInstance();
-
+  final usersPath = "users";
+  final firestore = MockFirestoreInstance();
   Map<String, dynamic> userDocumentMock(String userId) {
-    Map<String, dynamic> data = {
+    return {
       "id": userId,
       "updatedAt": DateTime.now(),
       "createdAt": DateTime.now(),
     };
-    return data;
   }
 
-  Future<List<Map<String, dynamic>>> createUsers({int times}) async {
+  Future<List<Map<String, dynamic>>> createUsers({required int times}) async {
     List<Map<String, dynamic>> userDataList = [];
-    for (int i = 1; i <= times; ++i) {
-      String userId = i.toString();
+    for (int i = 0; i < times; i++) {
+      final userId = i.toString();
       userDataList.add(userDocumentMock(userId));
     }
     return userDataList;
   }
 
-  setUp(() async {});
-  tearDown(() async {});
-
   group("batch", () {
     test("succees when create 500 documents at once.", () async {
       List<Map<String, dynamic>> userDataList = await createUsers(times: 500);
-      int userDataListLength = userDataList.length;
+      final userDataListLength = userDataList.length;
       for (int i = 0; i < userDataListLength; i = i + 500) {
-        int first = i;
-        int last = i + 500;
-        if (last >= userDataListLength) {
-          last = userDataListLength;
-        }
+        final first = i;
+        final last = min(i + 500, userDataListLength);
+
         var selectUserDataList = userDataList.getRange(first, last);
         var batch = firestore.batch();
-        await Future.forEach(selectUserDataList, (data) async {
-          var document = firestore.collection(users).doc("${data["id"]}");
-          batch.set(document, data);
-        });
+        for (final userData in selectUserDataList) {
+          final documentRef =
+              firestore.collection(usersPath).doc(userData["id"]);
+          batch.set(documentRef, userData);
+        }
         await batch.commit();
       }
-      QuerySnapshot result = await firestore.collection(users).get();
-      expect(result.docs.length, 1000);
+      QuerySnapshot result = await firestore.collection(usersPath).get();
+      expect(result.docs.length, 500);
     });
+
     test("fail when create 501 documents at once.", () async {
       List<Map<String, dynamic>> userDataList = await createUsers(times: 501);
-      int userDataListLength = userDataList.length;
-
-      for (int i = 0; i < userDataListLength; i = i + 501) {
-        int first = i;
-        int last = i + 501;
-        if (last >= userDataListLength) {
-          last = userDataListLength;
-        }
-        var selectUserDataList = userDataList.getRange(first, last);
-        var batch = firestore.batch();
-        await Future.forEach(selectUserDataList, (data) async {
-          var document = firestore.collection(users).doc("${data["id"]}");
-          batch.set(document, data);
-        });
-  QuerySnapshot result = await firestore.collection(users).get();
-        expect(result.docs.length, 0);
+      var batch = firestore.batch();
+      for (final userData in userDataList) {
+        final documentRef = firestore.collection(usersPath).doc(userData["id"]);
+        batch.set(documentRef, userData);
       }
+      expect(() => batch.commit(), throwsException);
     });
   });
 }

--- a/test/mock_batch_test.dart
+++ b/test/mock_batch_test.dart
@@ -25,7 +25,7 @@ void main() async {
   group('batch', () {
     test('succees when create 500 documents at once.', () async {
       final firestore = FakeFirebaseFirestore();
-      final userDataList = await createUsers(times: 500);
+      final userDataList =  createUsers(times: 500);
       final userDataListLength = userDataList.length;
       for (var i = 0; i < userDataListLength; i = i + 500) {
         final first = i;
@@ -46,7 +46,7 @@ void main() async {
 
     test('fail when create 501 documents at once.', () async {
       final firestore = FakeFirebaseFirestore();
-      final userDataList = await createUsers(times: 501);
+      final userDataList =  createUsers(times: 501);
       final batch = firestore.batch();
       for (final userData in userDataList) {
         final documentRef = firestore.collection(usersPath).doc(userData['id']);

--- a/test/mock_batch_test.dart
+++ b/test/mock_batch_test.dart
@@ -25,14 +25,14 @@ void main() async {
 
   group("batch", () {
     test("succees when create 500 documents at once.", () async {
-      List<Map<String, dynamic>> userDataList = await createUsers(times: 500);
+      final userDataList = await createUsers(times: 500);
       final userDataListLength = userDataList.length;
       for (int i = 0; i < userDataListLength; i = i + 500) {
         final first = i;
         final last = min(i + 500, userDataListLength);
 
-        var selectUserDataList = userDataList.getRange(first, last);
-        var batch = firestore.batch();
+        final selectUserDataList = userDataList.getRange(first, last);
+        final batch = firestore.batch();
         for (final userData in selectUserDataList) {
           final documentRef =
               firestore.collection(usersPath).doc(userData["id"]);
@@ -40,13 +40,13 @@ void main() async {
         }
         await batch.commit();
       }
-      QuerySnapshot result = await firestore.collection(usersPath).get();
+      final result = await firestore.collection(usersPath).get();
       expect(result.docs.length, 500);
     });
 
     test("fail when create 501 documents at once.", () async {
-      List<Map<String, dynamic>> userDataList = await createUsers(times: 501);
-      var batch = firestore.batch();
+      final userDataList = await createUsers(times: 501);
+      final batch = firestore.batch();
       for (final userData in userDataList) {
         final documentRef = firestore.collection(usersPath).doc(userData["id"]);
         batch.set(documentRef, userData);

--- a/test/mock_batch_test.dart
+++ b/test/mock_batch_test.dart
@@ -13,7 +13,7 @@ void main() async {
     };
   }
 
-  Future<List<Map<String, dynamic>>> createUsers({required int times}) async {
+  List<dynamic> createUsers({required int times}) async {
     final userDataList = [];
     for (var i = 0; i < times; i++) {
       final userId = i.toString();

--- a/test/mock_batch_test.dart
+++ b/test/mock_batch_test.dart
@@ -1,32 +1,33 @@
 import 'dart:math';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
-  final usersPath = "users";
-  final firestore = MockFirestoreInstance();
+  final usersPath = 'users';
+
   Map<String, dynamic> userDocumentMock(String userId) {
     return {
-      "id": userId,
-      "updatedAt": DateTime.now(),
-      "createdAt": DateTime.now(),
+      'id': userId,
+      'updatedAt': DateTime.now(),
+      'createdAt': DateTime.now(),
     };
   }
 
   Future<List<Map<String, dynamic>>> createUsers({required int times}) async {
-    List<Map<String, dynamic>> userDataList = [];
-    for (int i = 0; i < times; i++) {
+    final userDataList = [];
+    for (var i = 0; i < times; i++) {
       final userId = i.toString();
       userDataList.add(userDocumentMock(userId));
     }
     return userDataList;
   }
 
-  group("batch", () {
-    test("succees when create 500 documents at once.", () async {
+  group('batch', () {
+    test('succees when create 500 documents at once.', () async {
+      final firestore = FakeFirebaseFirestore();
       final userDataList = await createUsers(times: 500);
       final userDataListLength = userDataList.length;
-      for (int i = 0; i < userDataListLength; i = i + 500) {
+      for (var i = 0; i < userDataListLength; i = i + 500) {
         final first = i;
         final last = min(i + 500, userDataListLength);
 
@@ -34,7 +35,7 @@ void main() async {
         final batch = firestore.batch();
         for (final userData in selectUserDataList) {
           final documentRef =
-              firestore.collection(usersPath).doc(userData["id"]);
+              firestore.collection(usersPath).doc(userData['id']);
           batch.set(documentRef, userData);
         }
         await batch.commit();
@@ -43,11 +44,12 @@ void main() async {
       expect(result.docs.length, 500);
     });
 
-    test("fail when create 501 documents at once.", () async {
+    test('fail when create 501 documents at once.', () async {
+      final firestore = FakeFirebaseFirestore();
       final userDataList = await createUsers(times: 501);
       final batch = firestore.batch();
       for (final userData in userDataList) {
-        final documentRef = firestore.collection(usersPath).doc(userData["id"]);
+        final documentRef = firestore.collection(usersPath).doc(userData['id']);
         batch.set(documentRef, userData);
       }
       expect(() => batch.commit(), throwsException);

--- a/test/mock_batch_test.dart
+++ b/test/mock_batch_test.dart
@@ -1,0 +1,73 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  String users = "users";
+  MockFirestoreInstance firestore = MockFirestoreInstance();
+
+  Map<String, dynamic> userDocumentMock(String userId) {
+    Map<String, dynamic> data = {
+      "id": userId,
+      "updatedAt": DateTime.now(),
+      "createdAt": DateTime.now(),
+    };
+    return data;
+  }
+
+  Future<List<Map<String, dynamic>>> createUsers({int times}) async {
+    List<Map<String, dynamic>> userDataList = [];
+    for (int i = 1; i <= times; ++i) {
+      String userId = i.toString();
+      userDataList.add(userDocumentMock(userId));
+    }
+    return userDataList;
+  }
+
+  setUp(() async {});
+  tearDown(() async {});
+
+  group("batch", () {
+    test("succees when create 500 documents at once.", () async {
+      List<Map<String, dynamic>> userDataList = await createUsers(times: 500);
+      int userDataListLength = userDataList.length;
+      for (int i = 0; i < userDataListLength; i = i + 500) {
+        int first = i;
+        int last = i + 500;
+        if (last >= userDataListLength) {
+          last = userDataListLength;
+        }
+        var selectUserDataList = userDataList.getRange(first, last);
+        var batch = firestore.batch();
+        await Future.forEach(selectUserDataList, (data) async {
+          var document = firestore.collection(users).doc("${data["id"]}");
+          batch.set(document, data);
+        });
+        await batch.commit();
+      }
+      QuerySnapshot result = await firestore.collection(users).get();
+      expect(result.docs.length, 1000);
+    });
+    test("fail when create 501 documents at once.", () async {
+      List<Map<String, dynamic>> userDataList = await createUsers(times: 501);
+      int userDataListLength = userDataList.length;
+
+      for (int i = 0; i < userDataListLength; i = i + 501) {
+        int first = i;
+        int last = i + 501;
+        if (last >= userDataListLength) {
+          last = userDataListLength;
+        }
+        var selectUserDataList = userDataList.getRange(first, last);
+        var batch = firestore.batch();
+        await Future.forEach(selectUserDataList, (data) async {
+          var document = firestore.collection(users).doc("${data["id"]}");
+          batch.set(document, data);
+        });
+  QuerySnapshot result = await firestore.collection(users).get();
+        expect(result.docs.length, 0);
+      }
+    });
+  });
+}


### PR DESCRIPTION
batch has write restrictions. I added this code because this mock passes the test without the batch limitation.
https://firebase.google.com/docs/firestore/manage-data/transactions