### PR TITLE
Update version of cloud_firestore to ^3.0.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^2.2.0
+  cloud_firestore: ^3.0.0
   firebase_core: ^1.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^2.2.0
+  cloud_firestore: ^3.0.0
   cloud_firestore_platform_interface: ^5.0.1
   collection: ^1.14.13
   plugin_platform_interface: ^2.0.0


### PR DESCRIPTION
The current latest version of fake_cloud_firestore does not run when combined with cloud_firestore version ^3.0.0.
This pull request just updates the cloud_firestore version used in the pub spec.yaml files to also enable working with cloud_firestore version ^3.0.0