### PR TITLE
On removing document do not call the converter if document doesn't exists.

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -217,7 +217,9 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
     rootParent.remove(id);
     _firestore.removeSavedDocument(path);
     QuerySnapshotStreamManager().fireSnapshotUpdate(firestore, path);
-    fireSnapshotUpdate();
+    if (_exists()) {      
+      fireSnapshotUpdate();
+    }    
     return Future.value();
   }
 


### PR DESCRIPTION
When deleting a document the method `fireSnapshotUpdate` is called triggering a call to the converter (after some levels). The problem on calling the converter with the document as `_exists()` being false is that will trigger a null problem inside the converter (that requires non null values per Firebase lib). 

After looking the code I didn't understand the reasons on calling the `get()` method and subsequently the converter for a remove operation, so I added this verification before. All the tests are passing, so I hope this solves the issue #191.