### PR TITLE
add FieldPath support to doc.get()

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -54,12 +54,21 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
   @override
   SnapshotMetadata get metadata => _metadata;
 
-  bool _isCompositeKey(String key) {
-    return key.contains('.');
+  bool _isCompositeKey(dynamic key) {
+    if (key is String) {
+      return key.contains('.');
+    } else if (key is FieldPath) {
+      return true;
+    } else {
+      throw ArgumentError(
+          'key must be String or FieldPath but found ${key.runtimeType}');
+    }
   }
 
-  dynamic getCompositeKeyValue(String key) {
-    final compositeKeyElements = key.split('.');
+  dynamic getCompositeKeyValue(dynamic key) {
+    final compositeKeyElements = key is String
+        ? (key as String).split('.')
+        : (key as FieldPath).components;
     dynamic value = _rawDocument!;
     for (final keyElement in compositeKeyElements) {
       value = value[keyElement];

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -574,6 +574,27 @@ void main() {
     });
   });
 
+  group('Field paths', () {
+    test('Get "a.b" type paths', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.doc('root/foo').set({
+        'a': {'b': 'c'}
+      });
+      final document = await firestore.doc('root/foo').get();
+      expect(document.get('a.b'), 'c');
+    });
+
+    test('Get FieldPath type paths', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.doc('root/foo').set({
+        'a': {'I.have.dots': 'c'}
+      });
+      final document = await firestore.doc('root/foo').get();
+      // this FieldPath can't be done "a.b" style because the field has dots in it
+      expect(document.get(FieldPath(['a', 'I.have.dots'])), 'c');
+    });
+  });
+
   test('set to nested docs', () async {
     final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({


### PR DESCRIPTION
The Firestore documentation at [https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html#get](https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html#get) shows you should be able to do gets like this `documentSnapshot.get('a.b')` to access child fields directly.  Here's a full example from that page:

> documentRef.set({ a: { b: 'c' }}).then(() => {
>   return documentRef.get();
> }).then(documentSnapshot => {
>   let field = documentSnapshot.get('a.b');
>   console.log(`Retrieved field value: ${field}`);
> });

This currently works in fake_cloud_firestore.  What's missing is that the spec says you should be able to use a FieldPath object instead of a String as the key.  The reason for this is that a field name can have dots in it.  So for example you may need to use `FieldPath(['a','I.have.dots'])` in order to access such a field because obviously `'a.I.have.dots'` would be trying to lookup a different field than the one you intended.

This PR provides unit tests to test both of these scenarios (although the first scenario was working already, I didn't find a test for it).  The second test may illustrate what this is trying to solve better than my explanation above.