### PR TITLE
Fix notequalto query

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -54,12 +54,21 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
   @override
   SnapshotMetadata get metadata => _metadata;
 
-  bool _isCompositeKey(String key) {
-    return key.contains('.');
+  bool _isCompositeKey(dynamic key) {
+    if (key is String) {
+      return key.contains('.');
+    } else if (key is FieldPath) {
+      return true;
+    } else {
+      throw ArgumentError(
+          'key must be String or FieldPath but found ${key.runtimeType}');
+    }
   }
 
-  dynamic getCompositeKeyValue(String key) {
-    final compositeKeyElements = key.split('.');
+  dynamic getCompositeKeyValue(dynamic key) {
+    final compositeKeyElements = key is String
+        ? (key as String).split('.')
+        : (key as FieldPath).components;
     dynamic value = _rawDocument!;
     for (final keyElement in compositeKeyElements) {
       value = value[keyElement];

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -204,7 +204,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
     final operation =
         (List<DocumentSnapshot<T>> docs) => docs.where((document) {
               dynamic value;
-              if (field is String) {
+              if (field is String || field is FieldPath) {
                 value = document.get(field);
               } else if (field == FieldPath.documentId) {
                 value = document.id;
@@ -238,7 +238,8 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
     if (isEqualTo != null) {
       return value == isEqualTo;
     } else if (isNotEqualTo != null) {
-      return value != isNotEqualTo;
+      // requires that value is not null AND not equal to the argument
+      return value != null && value != isNotEqualTo;
     } else if (isNull != null) {
       final valueIsNull = value == null;
       return isNull ? valueIsNull : !valueIsNull;

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -574,6 +574,27 @@ void main() {
     });
   });
 
+  group('Field paths', () {
+    test('Get "a.b" type paths', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.doc('root/foo').set({
+        'a': {'b': 'c'}
+      });
+      final document = await firestore.doc('root/foo').get();
+      expect(document.get('a.b'), 'c');
+    });
+
+    test('Get FieldPath type paths', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.doc('root/foo').set({
+        'a': {'I.have.dots': 'c'}
+      });
+      final document = await firestore.doc('root/foo').get();
+      // this FieldPath can't be done "a.b" style because the field has dots in it
+      expect(document.get(FieldPath(['a', 'I.have.dots'])), 'c');
+    });
+  });
+
   test('set to nested docs', () async {
     final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -197,6 +197,72 @@ void main() {
     expect(hiddenSnapshot.docs.first.get('id'), equals('HIDDEN'));
   });
 
+  group('isNotEqualTo where clause for non existent', () {
+    test('with no nesting', () async {
+      final instance = FakeFirebaseFirestore();
+      final collection = instance.collection('test');
+      await collection.add({'a': 'b'});
+
+      final visibleSnapshot = (await instance
+          .collection('test')
+          .where('a', isNotEqualTo: '')
+          .get());
+      expect(visibleSnapshot.docs.length, equals(1));
+      expect(visibleSnapshot.docs.first.get('a'), equals('b'));
+
+      final emptySnapshot = (await instance
+          .collection('test')
+          .where('c', isNotEqualTo: '')
+          .get());
+      expect(emptySnapshot.docs.length, equals(0));
+    });
+
+    test('with string path nesting', () async {
+      final instance = FakeFirebaseFirestore();
+      final collection = instance.collection('test');
+      await collection.add({
+        'a': {'b': 'c'}
+      });
+
+      final visibleSnapshot = (await instance
+          .collection('test')
+          .where('a.b', isNotEqualTo: '')
+          .get());
+      expect(visibleSnapshot.docs.length, equals(1));
+      expect(visibleSnapshot.docs.first.get('a.b'), equals('c'));
+
+      final emptySnapshot = (await instance
+          .collection('test')
+          .where('a.c', isNotEqualTo: '')
+          .get());
+      expect(emptySnapshot.docs.length, equals(0));
+    });
+
+    test('with FieldPath', () async {
+      final instance = FakeFirebaseFirestore();
+      final collection = instance.collection('test');
+      await collection.add({
+        'users': {'test@example.com': 'I exist'}
+      });
+
+      final visibleSnapshot = (await instance
+          .collection('test')
+          .where(FieldPath(['users', 'test@example.com']), isNotEqualTo: '')
+          .get());
+      expect(visibleSnapshot.docs.length, equals(1));
+      expect(
+          visibleSnapshot.docs.first
+              .get(FieldPath(['users', 'test@example.com'])),
+          equals('I exist'));
+
+      final emptySnapshot = (await instance
+          .collection('test')
+          .where(FieldPath(['users', 'bogus@example.com']), isNotEqualTo: '')
+          .get());
+      expect(emptySnapshot.docs.length, equals(0));
+    });
+  });
+
   test('isNull where clause', () async {
     final instance = FakeFirebaseFirestore();
     await instance


### PR DESCRIPTION
The existing notEqualTo query implementation ignores the specification at [https://firebase.google.com/docs/firestore/query-data/queries#not_equal_](https://firebase.google.com/docs/firestore/query-data/queries#not_equal_) part that says 

> Use the not equal (!=) operator to return documents where the given field exists and does not match the comparison value

The part that's not implemented is `the given field exists`.  This PR resolves that issue.  It also allows the use of FieldPath values to specify the field instead of just String values (which the real Firestore supports).

This PR also provides test to verify fixed functionality, including the use of FieldPath.  It requires the previous PR I created #205 in order to have FieldPath support.