### PR TITLE
fixed a regression: restored firing the event when calling doc.delete() and implemented tests

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -216,7 +216,10 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
   Future<void> delete() {
     rootParent.remove(id);
     _firestore.removeSavedDocument(path);
+    // Notify on the parent collection.
     QuerySnapshotStreamManager().fireSnapshotUpdate(firestore, path);
+    // Notify the document listeners.
+    fireSnapshotUpdate();
     return Future.value();
   }
 


### PR DESCRIPTION
Fixes #196.

#192 introduced a regression where documents no longer fired an event when calling `doc.delete()`. This PR reintroduces the firing of the event. To prevent this issue from reoccurring, I implemented unit tests for it. Finally, since #191 reported some possible null exception when using converters, I also implemented unit tests using converters.