### PR TITLE
do not call converter.convert when making a snapshot for a deleted document

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -200,12 +200,18 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
       // Since there is no converter, we know that T is Map<String, dynamic>, so
       // it is safe to cast.
       return Future.value(rawSnapshot as DocumentSnapshot<T>);
+    } else {
+      // Convert the document. For some reason, it's still necessary to use ! on
+      // _converter.
+      final exists = _exists();
+      // If the document does not exist (eg has been deleted), there is no data
+      // to convert. The data is null.
+      final convertedData =
+          exists ? _converter!.fromFirestore(rawSnapshot, null) : null;
+      final convertedSnapshot = MockDocumentSnapshot<T>(this, _id,
+          docsData[_path], convertedData, /* converted */ true, exists);
+      return Future.value(convertedSnapshot);
     }
-    // Convert the document.
-    final convertedData = _converter!.fromFirestore(rawSnapshot, null);
-    final convertedSnapshot = MockDocumentSnapshot<T>(
-        this, _id, docsData[_path], convertedData, true, _exists());
-    return Future.value(convertedSnapshot);
   }
 
   bool _exists() {

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -8,8 +8,7 @@ import 'query_snapshot_matcher.dart';
 
 const uid = 'abc';
 
-final movieFromFirestore =
-    (snapshot, _) => Movie()..title = snapshot.get('title');
+final movieFromFirestore = (snapshot, _) => Movie()..title = snapshot['title'];
 final movieToFirestore = (Movie movie, _) => {'title': movie.title};
 
 void main() {

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -163,38 +163,12 @@ void main() {
       // Delete the document.
       await docRef.delete();
     });
-    test('with converter', () async {
-      final instance = FakeFirebaseFirestore();
-      final collectionRef = instance.collection('movies').withConverter(
-          fromFirestore: movieFromFirestore, toFirestore: movieToFirestore);
-      final docRef = collectionRef.doc(uid);
-      // Set document data. This does not fire an update since there is no
-      // listener yet.
-      await docRef.set(Movie()..title = 'Lawrence of Agrabah');
-
-      // snapshots() fires once, some time after it returns a stream.
-      final allSnapshots = docRef.snapshots();
-
-      // We forcefully await the doc snapshot with data. Without this, there is a
-      // race condition where docRef.delete() runs before, and so snapshots()
-      // fires the first snapshot with no data.
-      expect((await allSnapshots.first).data()?.title,
-          equals('Lawrence of Agrabah'));
-
-      // Now we wait for the last snapshot after the deletion.
-      allSnapshots.listen(expectAsync1((snap) {
-        expect(snap.data(), isNull);
-        expect(snap.exists, false);
-      }, count: 1));
-
-      // Delete the document.
-      await docRef.delete();
-    });
-
     test('with converter and does not call converter with null data', () async {
       final instance = FakeFirebaseFirestore();
       final collectionRef = instance.collection('movies').withConverter(
           fromFirestore: (docSnapshot, options) {
+            // Make sure that MockDocumentReference does not try to convert with
+            // null data.
             expect(docSnapshot.data(), isNotNull);
             return Movie()..title = docSnapshot.data()!['title'];
           },


### PR DESCRIPTION
Fixes #191.

According to https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/FromFirestore.html, the converter should return a non-null value. So it is expected that the converter is always called with valid data.

So instead of expecting the converters to be able to handle document snapshots with no data, `MockDocumentReference.get()` will return a converted `MockDocumentSnapshot` with null data without calling the converter.