### PR TITLE
Make some tests that should fail, actually fail.

### DIFF
--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -115,7 +115,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       values: values,
       f: (docs, index, exactMatch) => docs.sublist(
             0,
-            index == -1 ? docs.length : index + 1,
+            index,
           ));
 
   /// Utility function to avoid duplicate code for cursor query modifier
@@ -150,7 +150,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       if (docs.isEmpty) return docs;
 
       var res;
-      var found = false;
+      var exactMatch = false;
       for (var i = 0; i < values.length; i++) {
         var sublist = docs.sublist(res ?? 0);
         final keyName = orderByKeys[i];
@@ -163,11 +163,12 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
               final docValue = doc.get(keyName);
               return docValue.compareTo(searchedValue) == -1;
             });
-        found = sublist[index].get(keyName) == searchedValue;
+        exactMatch = index < sublist.length &&
+            sublist[index].get(keyName) == searchedValue;
         res = res == null ? index : res + index;
       }
 
-      return f(docs, res ?? -1, found);
+      return f(docs, res ?? -1, exactMatch);
     });
   }
 

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1127,7 +1127,7 @@ void main() {
     ]);
   });
 
-  test('startAt/endAt', () async {
+  test('orderBy', () async {
     final instance = FakeFirebaseFirestore();
 
     await instance.collection('cities').doc().set({
@@ -1150,12 +1150,22 @@ void main() {
       'state': 'Massachusetts',
     });
 
-    final baseQuery =
-        instance.collection('cities').orderBy('name').orderBy('state');
+    await instance.collection('cities').doc().set({
+      'name': 'Washington',
+      'state': 'Washington',
+    });
 
-    var snapshots = await baseQuery.startAt(['Springfield']).get();
+    final snapshots = await instance
+        .collection('cities')
+        .orderBy('name')
+        .orderBy('state')
+        .get();
 
     expect(snapshots.docs.toData(), [
+      {
+        'name': 'Los Angeles',
+        'state': 'California',
+      },
       {
         'name': 'Springfield',
         'state': 'Massachusetts',
@@ -1168,9 +1178,69 @@ void main() {
         'name': 'Springfield',
         'state': 'Wisconsin',
       },
+      {
+        'name': 'Washington',
+        'state': 'Washington',
+      }
+    ]);
+  });
+
+  test('startAt', () async {
+    final instance = FakeFirebaseFirestore();
+
+    await instance.collection('cities').doc().set({
+      'name': 'Los Angeles',
+      'state': 'California',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Springfield',
+      'state': 'Wisconsin',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Springfield',
+      'state': 'Missouri',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Springfield',
+      'state': 'Massachusetts',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Washington',
+      'state': 'Washington',
+    });
+
+    final baseQuery =
+        instance.collection('cities').orderBy('name').orderBy('state');
+
+    var snapshots = await baseQuery.startAt(['Los Angeles']).get();
+
+    expect(snapshots.docs.toData(), [
+      {
+        'name': 'Los Angeles',
+        'state': 'California',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Massachusetts',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Missouri',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Wisconsin',
+      },
+      {
+        'name': 'Washington',
+        'state': 'Washington',
+      }
     ]);
 
-    // Since there is no Springfield, Florida in our docs, it should ignore the second orderBy value
     snapshots = await baseQuery.startAt(['Springfield', 'Florida']).get();
 
     expect(snapshots.docs.toData(), [
@@ -1186,6 +1256,10 @@ void main() {
         'name': 'Springfield',
         'state': 'Wisconsin',
       },
+      {
+        'name': 'Washington',
+        'state': 'Washington',
+      }
     ]);
 
     snapshots = await baseQuery.startAt(['Springfield', 'Missouri']).get();
@@ -1199,15 +1273,52 @@ void main() {
         'name': 'Springfield',
         'state': 'Wisconsin',
       },
+      {
+        'name': 'Washington',
+        'state': 'Washington',
+      }
     ]);
 
+    snapshots = await baseQuery.startAt(['Wellington']).get();
+    expect(snapshots.docs.toData(), []);
+  });
+
+  test('endAt', () async {
+    final instance = FakeFirebaseFirestore();
+
+    await instance.collection('cities').doc().set({
+      'name': 'Los Angeles',
+      'state': 'California',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Springfield',
+      'state': 'Wisconsin',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Springfield',
+      'state': 'Missouri',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Springfield',
+      'state': 'Massachusetts',
+    });
+
+    await instance.collection('cities').doc().set({
+      'name': 'Washington',
+      'state': 'Washington',
+    });
+
+    final baseQuery =
+        instance.collection('cities').orderBy('name').orderBy('state');
+
+    var snapshots = await baseQuery.endAt(['Arizona']).get();
+    expect(snapshots.docs.toData(), []);
+
     snapshots = await baseQuery.endAt(['Springfield']).get();
-    // TODO(https://github.com/atn832/fake_cloud_firestore/issues/166):
-    // The actual Firestore returns:
-    // {name: Los Angeles, state: California},
-    // {name: Springfield, state: Massachusetts},
-    // {name: Springfield, state: Missouri},
-    // {name: Springfield, state: Wisconsin}.
+
     expect(snapshots.docs.toData(), [
       {
         'name': 'Los Angeles',
@@ -1216,21 +1327,24 @@ void main() {
       {
         'name': 'Springfield',
         'state': 'Massachusetts',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Missouri',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Wisconsin',
       },
     ]);
 
     // Since there is no Springfield, Florida in our docs, it should ignore the second orderBy value
     snapshots = await baseQuery.endAt(['Springfield', 'Florida']).get();
-    // TODO(https://github.com/atn832/fake_cloud_firestore/issues/167):
-    // the actual Firestore returns {name: Los Angeles, state: California}.
+
     expect(snapshots.docs.toData(), [
       {
         'name': 'Los Angeles',
         'state': 'California',
-      },
-      {
-        'name': 'Springfield',
-        'state': 'Massachusetts',
       },
     ]);
 
@@ -1249,6 +1363,30 @@ void main() {
         'name': 'Springfield',
         'state': 'Missouri',
       },
+    ]);
+
+    snapshots = await baseQuery.endAt(['Wellington']).get();
+    expect(snapshots.docs.toData(), [
+      {
+        'name': 'Los Angeles',
+        'state': 'California',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Massachusetts',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Missouri',
+      },
+      {
+        'name': 'Springfield',
+        'state': 'Wisconsin',
+      },
+      {
+        'name': 'Washington',
+        'state': 'Washington',
+      }
     ]);
   });
 

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1216,7 +1216,8 @@ void main() {
     final baseQuery =
         instance.collection('cities').orderBy('name').orderBy('state');
 
-    var snapshots = await baseQuery.startAt(['Los Angeles']).get();
+    // should get everything because it is before any document in the DB
+    var snapshots = await baseQuery.startAt(['Alaska']).get();
 
     expect(snapshots.docs.toData(), [
       {
@@ -1278,7 +1279,8 @@ void main() {
         'state': 'Washington',
       }
     ]);
-
+    // should not get anything because wellington is alphabetically greater
+    // than every document in db
     snapshots = await baseQuery.startAt(['Wellington']).get();
     expect(snapshots.docs.toData(), []);
   });
@@ -1364,7 +1366,8 @@ void main() {
         'state': 'Missouri',
       },
     ]);
-
+    // should get everything because wellington is alphabetically greater
+    // than every document in db
     snapshots = await baseQuery.endAt(['Wellington']).get();
     expect(snapshots.docs.toData(), [
       {


### PR DESCRIPTION
Make some tests that should fail, actually fail. The fact that the tests were engineered to succeed is concerning.

From those failing tests we can see that `orderBy` is failing, `endAt` and `startAt`

Side effect of closing https://github.com/atn832/fake_cloud_firestore/issues/204