### PR TITLE
Fix bug with replacing non-map values with map

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -119,7 +119,8 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
   void _applyValues(Map<String, dynamic> document, String key, dynamic value) {
     // Handle the recursive case.
     if (value is Map<String, dynamic>) {
-      if (!document.containsKey(key)) {
+      if (!document.containsKey(key) ||
+          !(document[key] is Map<String, dynamic>)) {
         document[key] = <String, dynamic>{};
       }
       value.forEach((subkey, subvalue) {

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -1367,10 +1367,9 @@ void main() {
       var newMap = {
         'testVal': {'innerKey': 'innerVal'}
       };
-      await firestore
-          .collection('testCollection')
-          .doc('testDoc')
-          .update(newMap);
+      expect(
+          firestore.collection('testCollection').doc('testDoc').update(newMap),
+          completes);
     });
   });
 }

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -1354,6 +1354,24 @@ void main() {
         expect(snapshot.docs.first.data()!.title, equals(MovieTitle));
       }));
     });
+
+    test('Replace Null with Map', () async {
+      final firestore = FakeFirebaseFirestore();
+
+      var testMap = {'testVal': null};
+      await firestore
+          .collection('testCollection')
+          .doc('testDoc')
+          .update(testMap);
+
+      var newMap = {
+        'testVal': {'innerKey': 'innerVal'}
+      };
+      await firestore
+          .collection('testCollection')
+          .doc('testDoc')
+          .update(newMap);
+    });
   });
 }
 


### PR DESCRIPTION
Hi all, this is my first time contributing to a public codebase, so please let me know if there's anything out of place here.

# Problem: 
Previously the code worked under the assumption that if the new value for a given key was a map, and the key existed in the document, then the existing value was also a map. This is not always the case, as a value could be updated from an int to a map e.g. Admin.permissions = null => Admin.permissions = {deleteUser: False, createUser:True...}

In this case an unhandled TypeError is thrown and interrupts the update call.


# Solution:
This fix updates the code which identifies whether a given key already exists in the document for a new value of type map, and has it also check whether the existing value is of type Map. If either of these conditions is false, the key is assigned a blank Map as a value, before applying the new value.

Unit tests all passed, and this fixed the issue in the project where I identified it, so hopefully everything looks good here. Please let me know if there's anything in the code that should be changed, I'm eager for feedback, and thank you so much for sharing this plugin! You're doing fantastic work!