### PR TITLE
`DocumentReference.update` throws an exception when the document does not exist

### DIFF
--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -159,17 +159,7 @@ class MockCollectionReference<T extends Object?> extends MockQuery<T>
   @override
   Future<DocumentReference<T>> add(T data) async {
     final documentReference = doc();
-    // DocumentReference.update expects a Map<String, Object?>. See
-    // https://pub.dev/documentation/cloud_firestore/2.1.0/cloud_firestore/DocumentReference/update.html.
-    if (data is Map<String, Object?>) {
-      await documentReference.update(data);
-    } else if (_converter != null) {
-      // Use the converter.
-      await documentReference.update(_converter!.toFirestore(data, null));
-    } else {
-      throw StateError('This should never happen');
-    }
-
+    await documentReference.set(data);
     _firestore.saveDocument(documentReference.path);
     QuerySnapshotStreamManager().fireSnapshotUpdate(firestore, path);
     return documentReference;

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -97,6 +97,16 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
 
   @override
   Future<void> update(Map<String, dynamic> data) {
+    if (!_exists()) {
+      throw FirebaseException(
+          plugin: 'FakeFirestore',
+          code: 'cloud_firestore/not-found',
+          message: 'Some requested document was not found.');
+    }
+    return _updateNoCheck(data);
+  }
+
+  Future<void> _updateNoCheck(Map<String, dynamic> data) {
     validateDocumentValue(data);
     // Copy data so that subsequent change to `data` should not affect the data
     // stored in mock document.
@@ -184,7 +194,7 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
     } else {
       rawData = _converter!.toFirestore(data, null);
     }
-    return update(rawData);
+    return _updateNoCheck(rawData);
   }
 
   @override

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -15,7 +15,6 @@ import 'util.dart';
 
 const snapshotsStreamKey = '_snapshots';
 
-// ignore: subtype_of_sealed_class
 class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
   final String _id;
   final Map<String, dynamic> root;
@@ -103,10 +102,10 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
           code: 'cloud_firestore/not-found',
           message: 'Some requested document was not found.');
     }
-    return _updateNoCheck(data);
+    return _setRawData(data);
   }
 
-  Future<void> _updateNoCheck(Map<String, dynamic> data) {
+  Future<void> _setRawData(Map<String, dynamic> data) {
     validateDocumentValue(data);
     // Copy data so that subsequent change to `data` should not affect the data
     // stored in mock document.
@@ -194,7 +193,7 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
     } else {
       rawData = _converter!.toFirestore(data, null);
     }
-    return _updateNoCheck(rawData);
+    return _setRawData(rawData);
   }
 
   @override

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -97,10 +97,10 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
   @override
   Future<void> update(Map<String, dynamic> data) {
     if (!_exists()) {
-      throw FirebaseException(
+      return Future.error(FirebaseException(
           plugin: 'FakeFirestore',
           code: 'cloud_firestore/not-found',
-          message: 'Some requested document was not found.');
+          message: 'Some requested document was not found.'));
     }
     return _setRawData(data);
   }

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -105,6 +105,7 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
     return _setRawData(data);
   }
 
+  /// Sets document raw data. Does not check for existence.
   Future<void> _setRawData(Map<String, dynamic> data) {
     validateDocumentValue(data);
     // Copy data so that subsequent change to `data` should not affect the data

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -29,6 +29,23 @@ void main() {
       });
       expect(instance.dump(), equals(expectedDumpAfterset));
     });
+    test('Updates docs', () async {
+      final instance = FakeFirebaseFirestore();
+      final doc = instance.collection('users').doc(uid);
+      await doc.set({'name': 'Bob'});
+      await doc.update({'name': 'Chris'});
+      expect((await doc.get()).get('name'), equals('Chris'));
+    });
+    test('Update fails on non-existent docs', () async {
+      final instance = FakeFirebaseFirestore();
+      expect(
+        () async => await instance
+            .collection('messages')
+            .doc('newID')
+            .update({'name': 'A'}),
+        throwsA(isA<FirebaseException>()),
+      );
+    });
     test('Add adds data', () async {
       final instance = FakeFirebaseFirestore();
       final doc1 = await instance.collection('messages').add({
@@ -951,7 +968,7 @@ void main() {
     final foo = firestore.collection('users').doc('foo');
     await foo.set(<String, dynamic>{'name.firstName': 'OldValue Foo'});
     final bar = firestore.collection('users').doc('bar');
-    await foo.set(<String, dynamic>{'name.firstName': 'OldValue Bar'});
+    await bar.set(<String, dynamic>{'name.firstName': 'OldValue Bar'});
 
     final batch = firestore.batch();
     batch.update(foo, <String, dynamic>{'name.firstName': 'Foo'});

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -39,10 +39,8 @@ void main() {
     test('Update fails on non-existent docs', () async {
       final instance = FakeFirebaseFirestore();
       expect(
-        () async => await instance
-            .collection('messages')
-            .doc('newID')
-            .update({'name': 'A'}),
+        () =>
+            instance.collection('messages').doc('newID').update({'name': 'A'}),
         throwsA(isA<FirebaseException>()),
       );
     });

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -1373,10 +1373,7 @@ void main() {
       final firestore = FakeFirebaseFirestore();
 
       var testMap = {'testVal': null};
-      await firestore
-          .collection('testCollection')
-          .doc('testDoc')
-          .update(testMap);
+      await firestore.collection('testCollection').doc('testDoc').set(testMap);
 
       var newMap = {
         'testVal': {'innerKey': 'innerVal'}

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -39,8 +39,7 @@ void main() {
     test('Update fails on non-existent docs', () async {
       final instance = FakeFirebaseFirestore();
       expect(
-        () =>
-            instance.collection('messages').doc('newID').update({'name': 'A'}),
+        instance.collection('messages').doc('newID').update({'name': 'A'}),
         throwsA(isA<FirebaseException>()),
       );
     });


### PR DESCRIPTION
Fixes #40 and #152.