### PR TITLE
Adding maxAttempts to runTransaction to match the method signature of cloud firestore 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.5
+- `runTransaction` matches the method signature in cloud_firestore 3.4.0 by adding `maxAttempts`
+
 ## 1.2.4
 
 - make `Document.update` throw an exception if trying to update a non-existent document.

--- a/lib/src/fake_cloud_firestore_instance.dart
+++ b/lib/src/fake_cloud_firestore_instance.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
-    as firestore_interface;
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart' as firestore_interface;
 import 'package:flutter/services.dart';
 
 import 'mock_collection_reference.dart';
@@ -26,23 +25,19 @@ class FakeFirebaseFirestore implements FirebaseFirestore {
   @override
   CollectionReference<Map<String, dynamic>> collection(String path) {
     final segments = path.split('/');
-    assert(segments.length % 2 == 1,
-        'Invalid document reference. Collection references must have an odd number of segments');
-    return MockCollectionReference(this, path, getSubpath(_root, path),
-        _docsData, getSubpath(_snapshotStreamControllerRoot, path));
+    assert(segments.length % 2 == 1, 'Invalid document reference. Collection references must have an odd number of segments');
+    return MockCollectionReference(this, path, getSubpath(_root, path), _docsData, getSubpath(_snapshotStreamControllerRoot, path));
   }
 
   @override
-  CollectionReference<Map<String, dynamic>> collectionGroup(
-      String collectionId) {
+  CollectionReference<Map<String, dynamic>> collectionGroup(String collectionId) {
     assert(!collectionId.contains('/'), 'Collection ID should not contain "/"');
     return MockCollectionReference(
       this,
       collectionId,
       buildTreeIncludingCollectionId(_root, _root, collectionId, {}),
       _docsData,
-      buildTreeIncludingCollectionId(_snapshotStreamControllerRoot,
-          _snapshotStreamControllerRoot, collectionId, {}),
+      buildTreeIncludingCollectionId(_snapshotStreamControllerRoot, _snapshotStreamControllerRoot, collectionId, {}),
       isCollectionGroup: true,
     );
   }
@@ -53,18 +48,9 @@ class FakeFirebaseFirestore implements FirebaseFirestore {
     // The actual behavior of Firestore for an invalid number of segments
     // differs by platforms. This library imitates it with assert.
     // https://github.com/atn832/fake_cloud_firestore/issues/30
-    assert(segments.length % 2 == 0,
-        'Invalid document reference. Document references must have an even number of segments');
+    assert(segments.length % 2 == 0, 'Invalid document reference. Document references must have an even number of segments');
     final documentId = segments.last;
-    return MockDocumentReference(
-        this,
-        path,
-        documentId,
-        getSubpath(_root, path),
-        _docsData,
-        _root,
-        getSubpath(_snapshotStreamControllerRoot, path),
-        null);
+    return MockDocumentReference(this, path, documentId, getSubpath(_root, path), _docsData, _root, getSubpath(_snapshotStreamControllerRoot, path), null);
   }
 
   @override
@@ -73,8 +59,11 @@ class FakeFirebaseFirestore implements FirebaseFirestore {
   }
 
   @override
-  Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler,
-      {Duration timeout = const Duration(seconds: 30)}) async {
+  Future<T> runTransaction<T>(
+    TransactionHandler<T> transactionHandler, {
+    Duration timeout = const Duration(seconds: 30),
+    int maxAttempts = 5,
+  }) async {
     Transaction transaction = _DummyTransaction();
     return await transactionHandler(transaction);
   }
@@ -116,8 +105,7 @@ class FakeFirebaseFirestore implements FirebaseFirestore {
   }
 
   void _setupFieldValueFactory() {
-    firestore_interface.FieldValueFactoryPlatform.instance =
-        MockFieldValueFactoryPlatform();
+    firestore_interface.FieldValueFactoryPlatform.instance = MockFieldValueFactoryPlatform();
   }
 
   // Required because FirebaseFirestore' == expects dynamic, while Mock's == expects an object.
@@ -134,13 +122,9 @@ class _DummyTransaction implements Transaction {
   bool _foundWrite = false;
 
   @override
-  Future<DocumentSnapshot<T>> get<T extends Object?>(
-      DocumentReference<T> documentReference) {
+  Future<DocumentSnapshot<T>> get<T extends Object?>(DocumentReference<T> documentReference) {
     if (_foundWrite) {
-      throw PlatformException(
-          code: '3',
-          message:
-              'Firestore transactions require all reads to be executed before all writes');
+      throw PlatformException(code: '3', message: 'Firestore transactions require all reads to be executed before all writes');
     }
     return documentReference.get();
   }
@@ -153,16 +137,14 @@ class _DummyTransaction implements Transaction {
   }
 
   @override
-  Transaction update(
-      DocumentReference documentReference, Map<String, dynamic> data) {
+  Transaction update(DocumentReference documentReference, Map<String, dynamic> data) {
     _foundWrite = true;
     documentReference.update(data);
     return this;
   }
 
   @override
-  Transaction set<T>(DocumentReference<T> documentReference, T data,
-      [SetOptions? options]) {
+  Transaction set<T>(DocumentReference<T> documentReference, T data, [SetOptions? options]) {
     _foundWrite = true;
     documentReference.set(data);
     return this;

--- a/lib/src/fake_cloud_firestore_instance.dart
+++ b/lib/src/fake_cloud_firestore_instance.dart
@@ -50,7 +50,16 @@ class FakeFirebaseFirestore implements FirebaseFirestore {
     // https://github.com/atn832/fake_cloud_firestore/issues/30
     assert(segments.length % 2 == 0, 'Invalid document reference. Document references must have an even number of segments');
     final documentId = segments.last;
-    return MockDocumentReference(this, path, documentId, getSubpath(_root, path), _docsData, _root, getSubpath(_snapshotStreamControllerRoot, path), null);
+    return MockDocumentReference(
+      this,
+      path,
+      documentId,
+      getSubpath(_root, path),
+      _docsData,
+      _root,
+      getSubpath(_snapshotStreamControllerRoot, path),
+      null,
+    );
   }
 
   @override


### PR DESCRIPTION
Fixes the error:
```bash
Error: The
method 'FakeFirebaseFirestore.runTransaction' doesn't have the named parameter 'maxAttempts' of overridden method
'FirebaseFirestore.runTransaction'.
  Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler
```
