### PR TITLE
fixed compile issue due to firestore api change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.5
+
+- added `maxAttempts` to `FirebaseFirestore.runTransaction` to match firestore 3.4.0.
+
 ## 1.2.4
 
 - make `Document.update` throw an exception if trying to update a non-existent document.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ See more examples at [fake_cloud_firestore/example/test/widget_test.dart](https:
 
 | cloud_firestore | fake_cloud_firestore  |
 |-----------------|-----------------------|
+| 3.4.0           | 1.2.5                 |
 | 3.0.0           | 1.2.1                 |
 | 2.2.0           | 1.1.0                 |
 | 2.1.0           | 1.0.2                 |

--- a/lib/src/fake_cloud_firestore_instance.dart
+++ b/lib/src/fake_cloud_firestore_instance.dart
@@ -74,7 +74,8 @@ class FakeFirebaseFirestore implements FirebaseFirestore {
 
   @override
   Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler,
-      {Duration timeout = const Duration(seconds: 30)}) async {
+      {Duration timeout = const Duration(seconds: 30),
+      int maxAttempts = 5}) async {
     Transaction transaction = _DummyTransaction();
     return await transactionHandler(transaction);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fake_cloud_firestore
 description: Previously known as cloud_firestore_mocks. Fake implementation of Cloud Firestore. Use this package to unit test apps that use Cloud Firestore.
-version: 1.2.4
+version: 1.2.5
 homepage: http://blog.wafrat.com
 repository: https://github.com/atn832/fake_cloud_firestore
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^3.0.0
+  cloud_firestore: ^3.4.0
   cloud_firestore_platform_interface: ^5.0.1
   collection: ^1.14.13
   plugin_platform_interface: ^2.0.0


### PR DESCRIPTION
Fixes #231.

Firestore 3.4.0 introduced a breaking change without changing the major version. So we do the same so that people who `flutter pub upgrade` get no compile issue.