### PR TITLE
Support DateTime in other Query.where operators

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -148,21 +148,8 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
       final fieldValue = fieldValuePlatform.value;
       fieldValue.updateDocument(document, key);
     } else {
-      document[key] = _transformValue(value);
+      document[key] = transformDates(value);
     }
-  }
-
-  dynamic _transformValue(dynamic value) {
-    if (value is Map<String, dynamic>) {
-      return value.map((k, v) => MapEntry(k, _transformValue(v)));
-    }
-    if (value is Iterable) {
-      return value.map((e) => _transformValue(e)).toList();
-    }
-    if (value is DateTime) {
-      return Timestamp.fromDate(value);
-    }
-    return value;
   }
 
   Map<String, dynamic> _findNestedDocumentToUpdate(String key) {

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -147,11 +147,22 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
       final fieldValuePlatform = valueDelegate as MockFieldValuePlatform;
       final fieldValue = fieldValuePlatform.value;
       fieldValue.updateDocument(document, key);
-    } else if (value is DateTime) {
-      document[key] = Timestamp.fromDate(value);
     } else {
-      document[key] = value;
+      document[key] = _transformValue(value);
     }
+  }
+
+  dynamic _transformValue(dynamic value) {
+    if (value is Map<String, dynamic>) {
+      return value.map((k, v) => MapEntry(k, _transformValue(v)));
+    }
+    if (value is Iterable) {
+      return value.map((e) => _transformValue(e)).toList();
+    }
+    if (value is DateTime) {
+      return Timestamp.fromDate(value);
+    }
+    return value;
   }
 
   Map<String, dynamic> _findNestedDocumentToUpdate(String key) {

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -244,6 +244,16 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
     return MockQuery<T>(this, operation);
   }
 
+  dynamic _transformDates(dynamic value) {
+    if(value is DateTime) {
+      return Timestamp.fromDate(value);
+    }
+    if(value is List){
+      return value.map((e) => _transformDates(e)).toList();
+    }
+    return value;
+  }
+
   bool _valueMatchesQuery(dynamic value,
       {dynamic isEqualTo,
       dynamic isNotEqualTo,
@@ -257,8 +267,10 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       List<dynamic>? whereNotIn,
       bool? isNull}) {
     if (isEqualTo != null) {
+      isEqualTo = _transformDates(isEqualTo);
       return value == isEqualTo;
     } else if (isNotEqualTo != null) {
+      isNotEqualTo = _transformDates(isNotEqualTo);
       // requires that value is not null AND not equal to the argument
       return value != null && value != isNotEqualTo;
     } else if (isNull != null) {
@@ -269,37 +281,29 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       if (value is! Comparable) {
         return false;
       }
-      if (isGreaterThan is DateTime) {
-        isGreaterThan = Timestamp.fromDate(isGreaterThan);
-      }
+      isGreaterThan = _transformDates(isGreaterThan);
       return value.compareTo(isGreaterThan) > 0;
     } else if (isGreaterThanOrEqualTo != null) {
       if (value is! Comparable) {
         return false;
       }
-      if (isGreaterThanOrEqualTo is DateTime) {
-        isGreaterThanOrEqualTo = Timestamp.fromDate(isGreaterThanOrEqualTo);
-      }
+      isGreaterThanOrEqualTo = _transformDates(isGreaterThanOrEqualTo);
       return value.compareTo(isGreaterThanOrEqualTo) >= 0;
     } else if (isLessThan != null) {
       if (value is! Comparable) {
         return false;
       }
-      if (isLessThan is DateTime) {
-        isLessThan = Timestamp.fromDate(isLessThan);
-      }
+      isLessThan = _transformDates(isLessThan);
       return value.compareTo(isLessThan) < 0;
     } else if (isLessThanOrEqualTo != null) {
       if (value is! Comparable) {
         return false;
       }
-      if (isLessThanOrEqualTo is DateTime) {
-        isLessThanOrEqualTo = Timestamp.fromDate(isLessThanOrEqualTo);
-      }
+      isLessThanOrEqualTo = _transformDates(isLessThanOrEqualTo);
       return value.compareTo(isLessThanOrEqualTo) <= 0;
     } else if (arrayContains != null) {
       if (value is Iterable) {
-        return value.contains(arrayContains);
+        return value.contains(_transformDates(arrayContains));
       } else {
         return false;
       }
@@ -320,6 +324,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
         );
       }
       if (value is Iterable) {
+        arrayContainsAny = _transformDates(arrayContainsAny) as List;
         var valueSet = Set.from(value);
         for (var elem in arrayContainsAny) {
           if (valueSet.contains(elem)) {
@@ -341,6 +346,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
           'whereIn cannot be combined with arrayContainsAny',
         );
       }
+      whereIn = _transformDates(whereIn) as List;
       if (whereIn.contains(value)) {
         return true;
       }
@@ -356,6 +362,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
           'whereNotIn cannot be combined with arrayContainsAny',
         );
       }
+      whereNotIn = _transformDates(whereNotIn) as List;
       if (whereNotIn.contains(value)) {
         return false;
       }

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:fake_cloud_firestore/src/util.dart';
 import 'package:flutter/services.dart';
 import 'package:quiver/core.dart';
 
@@ -244,16 +245,6 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
     return MockQuery<T>(this, operation);
   }
 
-  dynamic _transformDates(dynamic value) {
-    if(value is DateTime) {
-      return Timestamp.fromDate(value);
-    }
-    if(value is Iterable){
-      return value.map((e) => _transformDates(e)).toList();
-    }
-    return value;
-  }
-
   bool _valueMatchesQuery(dynamic value,
       {dynamic isEqualTo,
       dynamic isNotEqualTo,
@@ -267,10 +258,10 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       List<dynamic>? whereNotIn,
       bool? isNull}) {
     if (isEqualTo != null) {
-      isEqualTo = _transformDates(isEqualTo);
+      isEqualTo = transformDates(isEqualTo);
       return value == isEqualTo;
     } else if (isNotEqualTo != null) {
-      isNotEqualTo = _transformDates(isNotEqualTo);
+      isNotEqualTo = transformDates(isNotEqualTo);
       // requires that value is not null AND not equal to the argument
       return value != null && value != isNotEqualTo;
     } else if (isNull != null) {
@@ -281,29 +272,29 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       if (value is! Comparable) {
         return false;
       }
-      isGreaterThan = _transformDates(isGreaterThan);
+      isGreaterThan = transformDates(isGreaterThan);
       return value.compareTo(isGreaterThan) > 0;
     } else if (isGreaterThanOrEqualTo != null) {
       if (value is! Comparable) {
         return false;
       }
-      isGreaterThanOrEqualTo = _transformDates(isGreaterThanOrEqualTo);
+      isGreaterThanOrEqualTo = transformDates(isGreaterThanOrEqualTo);
       return value.compareTo(isGreaterThanOrEqualTo) >= 0;
     } else if (isLessThan != null) {
       if (value is! Comparable) {
         return false;
       }
-      isLessThan = _transformDates(isLessThan);
+      isLessThan = transformDates(isLessThan);
       return value.compareTo(isLessThan) < 0;
     } else if (isLessThanOrEqualTo != null) {
       if (value is! Comparable) {
         return false;
       }
-      isLessThanOrEqualTo = _transformDates(isLessThanOrEqualTo);
+      isLessThanOrEqualTo = transformDates(isLessThanOrEqualTo);
       return value.compareTo(isLessThanOrEqualTo) <= 0;
     } else if (arrayContains != null) {
       if (value is Iterable) {
-        return value.contains(_transformDates(arrayContains));
+        return value.contains(transformDates(arrayContains));
       } else {
         return false;
       }
@@ -324,7 +315,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
         );
       }
       if (value is Iterable) {
-        arrayContainsAny = _transformDates(arrayContainsAny) as List;
+        arrayContainsAny = transformDates(arrayContainsAny) as List;
         var valueSet = Set.from(value);
         for (var elem in arrayContainsAny) {
           if (valueSet.contains(elem)) {
@@ -346,7 +337,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
           'whereIn cannot be combined with arrayContainsAny',
         );
       }
-      whereIn = _transformDates(whereIn) as List;
+      whereIn = transformDates(whereIn) as List;
       if (whereIn.contains(value)) {
         return true;
       }
@@ -362,7 +353,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
           'whereNotIn cannot be combined with arrayContainsAny',
         );
       }
-      whereNotIn = _transformDates(whereNotIn) as List;
+      whereNotIn = transformDates(whereNotIn) as List;
       if (whereNotIn.contains(value)) {
         return false;
       }

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -248,7 +248,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
     if(value is DateTime) {
       return Timestamp.fromDate(value);
     }
-    if(value is List){
+    if(value is Iterable){
       return value.map((e) => _transformDates(e)).toList();
     }
     return value;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -94,3 +94,19 @@ void validateDocumentValue(dynamic value) {
   }
   throw ArgumentError.value(value);
 }
+
+/// Converts DateTime to Timestamp.
+/// Handles complex structures like Map and List
+/// by recursively calling itself on each entry.
+dynamic transformDates(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value.map((k, v) => MapEntry(k, transformDates(v)));
+  }
+  if (value is Iterable) {
+    return value.map((e) => transformDates(e)).toList();
+  }
+  if (value is DateTime) {
+    return Timestamp.fromDate(value);
+  }
+  return value;
+}

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1477,4 +1477,87 @@ void main() {
     final movieFound = searchResults.docs.first.data();
     expect(movieFound.title, equals('Robot from the future'));
   });
+
+  group('Queries with DateTime', () {
+    late FirebaseFirestore firestore;
+    late CollectionReference collection;
+    late DateTime todayDate;
+
+    setUp(() async {
+      firestore = FakeFirebaseFirestore();
+      collection = firestore.collection('dates');
+      final now = DateTime.now();
+      todayDate = DateTime.utc(now.year, now.month, now.day);
+      await collection.doc().set({'date': todayDate});
+      await collection.doc().set({
+        'dates': [todayDate]
+      });
+    });
+
+    test('isEqualTo', () async {
+      final querySnapshot =
+          await collection.where('date', isEqualTo: todayDate).get();
+      expect(querySnapshot.docs, isNotEmpty);
+    });
+
+    test('isNotEqualTo', () async {
+      final querySnapshot = await collection
+          .where('date', isNotEqualTo: todayDate.add(Duration(days: 1)))
+          .get();
+      expect(querySnapshot.docs, isNotEmpty);
+    });
+
+    test('isGreaterThan', () async {
+      final querySnapshot = await collection
+          .where('date', isGreaterThan: todayDate.subtract(Duration(days: 1)))
+          .get();
+      expect(querySnapshot.docs, isNotEmpty);
+    });
+
+    test('isGreaterThanOrEqualTo', () async {
+      final querySnapshot = await collection
+          .where('date',
+              isGreaterThanOrEqualTo: todayDate.subtract(Duration(days: 1)))
+          .get();
+      expect(querySnapshot.docs, isNotEmpty);
+    });
+
+    test('isLessThan', () async {
+      final querySnapshot = await collection
+          .where('date', isLessThan: todayDate.add(Duration(days: 1)))
+          .get();
+      expect(querySnapshot.docs, isNotEmpty);
+    });
+
+    test('isLessThanOrEqualTo', () async {
+      final querySnapshot = await collection
+          .where('date', isLessThanOrEqualTo: todayDate.add(Duration(days: 1)))
+          .get();
+      expect(querySnapshot.docs, isNotEmpty);
+    });
+
+    test('arrayContains', () async {
+      final querySnapshot =
+          await collection.where('dates', arrayContains: todayDate).get();
+      expect(querySnapshot.docs, isNotEmpty);
+    }, skip: 'data with lists is not handled correctly');
+
+    test('arrayContainsAny', () async {
+      final querySnapshot =
+          await collection.where('dates', arrayContainsAny: [todayDate]).get();
+      expect(querySnapshot.docs, isNotEmpty);
+    }, skip: 'data with lists is not handled correctly');
+
+    test('whereIn', () async {
+      final querySnapshot =
+          await collection.where('dates', whereIn: [todayDate]).get();
+      expect(querySnapshot.docs, isNotEmpty);
+    }, skip: 'data with lists is not handled correctly');
+
+    test('whereNotIn', () async {
+      final querySnapshot = await collection
+          .where('dates', whereNotIn: [todayDate.add(Duration(days: 1))]).get();
+      expect(querySnapshot.docs, isNotEmpty);
+    }, skip: 'data with lists is not handled correctly');
+  });
 }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1540,24 +1540,24 @@ void main() {
       final querySnapshot =
           await collection.where('dates', arrayContains: todayDate).get();
       expect(querySnapshot.docs, isNotEmpty);
-    }, skip: 'data with lists is not handled correctly');
+    });
 
     test('arrayContainsAny', () async {
       final querySnapshot =
           await collection.where('dates', arrayContainsAny: [todayDate]).get();
       expect(querySnapshot.docs, isNotEmpty);
-    }, skip: 'data with lists is not handled correctly');
+    });
 
     test('whereIn', () async {
       final querySnapshot =
-          await collection.where('dates', whereIn: [todayDate]).get();
+          await collection.where('date', whereIn: [todayDate]).get();
       expect(querySnapshot.docs, isNotEmpty);
-    }, skip: 'data with lists is not handled correctly');
+    });
 
     test('whereNotIn', () async {
       final querySnapshot = await collection
-          .where('dates', whereNotIn: [todayDate.add(Duration(days: 1))]).get();
+          .where('date', whereNotIn: [todayDate.add(Duration(days: 1))]).get();
       expect(querySnapshot.docs, isNotEmpty);
-    }, skip: 'data with lists is not handled correctly');
+    });
   });
 }


### PR DESCRIPTION
**Summary**

- made sure that passing ```DateTime``` works with every applicable ```Query.where``` operator. I tested these types of queries on a real Firestore database and they all should work.
- improved support for data with lists. I don't know if this handles all the cases, but it fixed an issue in one of my projects.
- added tests for queries with ```DateTime```.


Fixes #228 