### PR TITLE
Add default Query.limit implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ example/android/local.properties
 **/ios/Runner.xcworkspace/xcuserdata/
 
 android/.gradle/
+android/local.properties
+
 
 *.log
 .idea

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,4 +1,0 @@
-sdk.dir=/Users/anhtuan/Library/Android/sdk
-flutter.sdk=/Users/anhtuan/flutter
-flutter.buildMode=debug
-flutter.versionName=0.9.0

--- a/lib/src/fake_converted_query.dart
+++ b/lib/src/fake_converted_query.dart
@@ -33,5 +33,8 @@ class FakeConvertedQuery<T extends Object?> extends FakeQueryWithParent<T> {
   FakeQueryWithParent? get parentQuery => _nonConvertedParentQuery;
 
   @override
+  Query<T> limit(int limit) => this;
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/lib/src/fake_converted_query.dart
+++ b/lib/src/fake_converted_query.dart
@@ -33,7 +33,11 @@ class FakeConvertedQuery<T extends Object?> extends FakeQueryWithParent<T> {
   FakeQueryWithParent? get parentQuery => _nonConvertedParentQuery;
 
   @override
-  Query<T> limit(int limit) => this;
+  Query<T> limit(int limit) {
+    return FakeConvertedQuery<T>(
+        _nonConvertedParentQuery.limit(limit) as FakeQueryWithParent,
+        _converter);
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dev_dependencies:
     sdk: flutter
   pedantic: ^1.9.0
   test: ^1.15.2
-  mocktail: ^0.3.0
 
 false_secrets:
   - google-services.json

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dev_dependencies:
     sdk: flutter
   pedantic: ^1.9.0
   test: ^1.15.2
+  mocktail: ^0.3.0
 
 false_secrets:
   - google-services.json

--- a/test/src/fake_converted_query_test.dart
+++ b/test/src/fake_converted_query_test.dart
@@ -1,0 +1,42 @@
+import 'package:fake_cloud_firestore/src/converter.dart';
+import 'package:fake_cloud_firestore/src/fake_converted_query.dart';
+import 'package:fake_cloud_firestore/src/fake_query_with_parent.dart';
+import 'package:fake_cloud_firestore/src/mock_query.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+// ignore: subtype_of_sealed_class
+class MockFakeQueryWithParent<T> extends Mock implements MockQuery<T> {}
+
+class MockConverter<T> extends Mock implements Converter<T> {}
+
+void main() {
+  test('FakeQueryWithParentImpl.limit should throw NoSuchMethodError', () {
+    expect(
+      () => FakeQueryWithParentImpl().limit(1),
+      throwsA(isA<NoSuchMethodError>()),
+    );
+  });
+
+  test('FakeConvertedQuery.limit should return normally', () {
+    // arrange
+    final mockFakeQueryWithParent =
+        MockFakeQueryWithParent<Map<String, dynamic>>();
+    final mockConverter = MockConverter<Map<String, dynamic>>();
+
+    // act
+    final query = FakeConvertedQuery<Map<String, dynamic>>(
+      mockFakeQueryWithParent,
+      mockConverter,
+    );
+
+    // assert
+    expect(() => query.limit(1), returnsNormally);
+  });
+}
+
+// ignore: subtype_of_sealed_class
+class FakeQueryWithParentImpl extends FakeQueryWithParent {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/src/fake_converted_query_test.dart
+++ b/test/src/fake_converted_query_test.dart
@@ -11,13 +11,6 @@ class MockFakeQueryWithParent<T> extends Mock implements MockQuery<T> {}
 class MockConverter<T> extends Mock implements Converter<T> {}
 
 void main() {
-  test('FakeQueryWithParentImpl.limit should throw NoSuchMethodError', () {
-    expect(
-      () => FakeQueryWithParentImpl().limit(1),
-      throwsA(isA<NoSuchMethodError>()),
-    );
-  });
-
   test('FakeConvertedQuery.limit should return normally', () {
     // arrange
     final mockFakeQueryWithParent =

--- a/test/src/fake_converted_query_test.dart
+++ b/test/src/fake_converted_query_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../fake_cloud_firestore_test.dart';
 
 void main() {
-  test('`limit` clips results', () async {
+  test('limit clips results', () async {
     final from = (snapshot, _) => Movie()..title = snapshot['title'];
     final to = (Movie movie, _) => {'title': movie.title};
 
@@ -15,7 +15,12 @@ void main() {
         .withConverter(fromFirestore: from, toFirestore: to);
     await moviesCollection.add(Movie()..title = 'A long time ago');
     await moviesCollection.add(Movie()..title = 'Robot from the future');
-    final searchResults = await moviesCollection.limit(1).get();
+    final rawMoviesCollection = firestore.collection('movies');
+    final searchResults = await rawMoviesCollection
+        .where('title', isNotEqualTo: 'Galactic')
+        .withConverter(fromFirestore: from, toFirestore: to)
+        .limit(1)
+        .get();
     expect(searchResults.size, equals(1));
     final movieFound = searchResults.docs.first.data();
     expect(movieFound.title, equals('A long time ago'));


### PR DESCRIPTION
`Query.limit` has not been implemented thus resulting in the following:
```
Class 'FakeConvertedQuery<Job>' has no instance method 'limit' with matching arguments.
Receiver: Instance of 'FakeConvertedQuery<Job>'
Tried calling: limit(11)
Found: limit(int) => Query<X0>
```

This PR provides a default `limit` implementation.

Fixes #198