### PR TITLE
Fix inconsistencies with original plugin

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -28,7 +28,12 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
   @override
   dynamic get(dynamic key) {
     if (_isCompositeKey(key)) {
-      return getCompositeKeyValue(key);
+      return _getCompositeKeyValue(key);
+    }
+    if (!_exists || _rawDocument?.containsKey(key) != true) {
+      throw StateError(!_exists
+          ? 'Cannot get field if DataSnapshot does not exist.'
+          : 'Cannot get field that does not exist');
     }
     return _rawDocument?[key];
   }
@@ -65,13 +70,15 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
     }
   }
 
-  dynamic getCompositeKeyValue(dynamic key) {
+  dynamic _getCompositeKeyValue(dynamic key) {
     final compositeKeyElements =
         key is String ? key.split('.') : (key as FieldPath).components;
     dynamic value = _rawDocument!;
     for (final keyElement in compositeKeyElements) {
+      if (!(value is Map) || !value.containsKey(keyElement)) {
+        throw StateError('Cannot get field that does not exist');
+      }
       value = value[keyElement];
-      if (value == null) return null;
     }
     return value;
   }

--- a/lib/src/mock_field_value_platform.dart
+++ b/lib/src/mock_field_value_platform.dart
@@ -1,8 +1,10 @@
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:fake_cloud_firestore/src/util.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 abstract class FakeFieldValue {
   const FakeFieldValue();
+
   static const delete = FieldValueDelete();
   static const serverTimestamp = FieldValueServerTimestamp();
 
@@ -29,6 +31,7 @@ class FieldValueDelete extends FakeFieldValue {
 
 class FieldValueIncrement extends FakeFieldValue {
   const FieldValueIncrement(this.value);
+
   final num value;
 
   @override
@@ -45,6 +48,7 @@ class FieldValueIncrement extends FakeFieldValue {
 
 class FieldValueArrayUnion extends FakeFieldValue {
   const FieldValueArrayUnion(this.elements);
+
   final List<dynamic> elements;
 
   @override
@@ -55,7 +59,7 @@ class FieldValueArrayUnion extends FakeFieldValue {
     // https://firebase.google.com/docs/reference/js/firebase.firestore.FieldValue#arrayunion
     final updatedValue = previousValue is List ? List.from(previousValue) : [];
     for (final item in elements) {
-      if (!updatedValue.contains(item)) {
+      if (!updatedValue.any((element) => deepEqual(element, item))) {
         updatedValue.add(item);
       }
     }
@@ -65,6 +69,7 @@ class FieldValueArrayUnion extends FakeFieldValue {
 
 class FieldValueArrayRemove extends FakeFieldValue {
   const FieldValueArrayRemove(this.elements);
+
   final List<dynamic> elements;
 
   @override
@@ -74,7 +79,8 @@ class FieldValueArrayRemove extends FakeFieldValue {
     // overwritten with an empty array.
     // https://firebase.google.com/docs/reference/js/firebase.firestore.FieldValue#arrayunion
     final updatedValue = previousValue is List ? List.from(previousValue) : [];
-    updatedValue.removeWhere((item) => elements.contains(item));
+    updatedValue.removeWhere(
+        (item) => elements.any((element) => deepEqual(element, item)));
     document[key] = updatedValue;
   }
 }

--- a/lib/src/mock_field_value_platform.dart
+++ b/lib/src/mock_field_value_platform.dart
@@ -47,7 +47,8 @@ class FieldValueIncrement extends FakeFieldValue {
 }
 
 class FieldValueArrayUnion extends FakeFieldValue {
-  const FieldValueArrayUnion(this.elements);
+  FieldValueArrayUnion(List<dynamic> _elements)
+      : elements = transformDates(_elements);
 
   final List<dynamic> elements;
 
@@ -68,7 +69,8 @@ class FieldValueArrayUnion extends FakeFieldValue {
 }
 
 class FieldValueArrayRemove extends FakeFieldValue {
-  const FieldValueArrayRemove(this.elements);
+  FieldValueArrayRemove(List<dynamic> _elements)
+      : elements = transformDates(_elements);
 
   final List<dynamic> elements;
 

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -225,7 +225,14 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
         (List<DocumentSnapshot<T>> docs) => docs.where((document) {
               dynamic value;
               if (field is String || field is FieldPath) {
-                value = document.get(field);
+                // DocumentSnapshot.get can throw StateError
+                // if field cannot be found. In query it does not matter,
+                // so catch and set value to null.
+                try {
+                  value = document.get(field);
+                } on StateError catch (_) {
+                  value = null;
+                }
               } else if (field == FieldPath.documentId) {
                 value = document.id;
               }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -115,29 +115,35 @@ dynamic transformDates(dynamic value) {
   return value;
 }
 
-bool iterableEqual(Iterable v1, Iterable v2) {
-  if (v1.length != v2.length) {
-    return false;
-  }
-
-  for (var i = 0; i < v1.length; i++) {
-    if (v1.elementAt(i) != v2.elementAt(i)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
+/// Compares two values, handles Lists and Maps
+/// by recursively calling itself on each entry.
+/// For Lists:
+///   - length has to be the same.
+///   - for each index, value in the other List at that index must be the same.
+/// For Maps:
+///   - keys must be the same.
+///   - for each key, value in the other Map at that key must be the same.
+/// For other types uses default implementation.
 bool deepEqual(dynamic v1, dynamic v2) {
   if (v1 is Map && v2 is Map) {
     return v1.keys.length == v2.keys.length &&
         v1.keys.every((key) => deepEqual(v1[key], v2[key]));
   }
 
-  if (v1 is Iterable && v2 is Iterable) {
-    return iterableEqual(v1, v2);
+  if (v1 is List && v2 is List) {
+    if (v1.length != v2.length) {
+      return false;
+    }
+
+    for (var i = 0; i < v1.length; i++) {
+      if (!deepEqual(v1[i], v2[i])) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
+  // fallback to default comparison
   return v1 == v2;
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:collection/collection.dart';
 
 dynamic getSubpath(Map<String, dynamic> root, String path) {
   return _getSubpath(root, path.split('/'));
@@ -115,35 +116,7 @@ dynamic transformDates(dynamic value) {
   return value;
 }
 
-/// Compares two values, handles Lists and Maps
-/// by recursively calling itself on each entry.
-/// For Lists:
-///   - length has to be the same.
-///   - for each index, value in the other List at that index must be the same.
-/// For Maps:
-///   - keys must be the same.
-///   - for each key, value in the other Map at that key must be the same.
-/// For other types uses default implementation.
+/// Convenience method for comparison of collections, e.g. Lists, Maps.
 bool deepEqual(dynamic v1, dynamic v2) {
-  if (v1 is Map && v2 is Map) {
-    return v1.keys.length == v2.keys.length &&
-        v1.keys.every((key) => deepEqual(v1[key], v2[key]));
-  }
-
-  if (v1 is List && v2 is List) {
-    if (v1.length != v2.length) {
-      return false;
-    }
-
-    for (var i = 0; i < v1.length; i++) {
-      if (!deepEqual(v1[i], v2[i])) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  // fallback to default comparison
-  return v1 == v2;
+  return DeepCollectionEquality().equals(v1, v2);
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -110,3 +110,30 @@ dynamic transformDates(dynamic value) {
   }
   return value;
 }
+
+bool iterableEqual(Iterable v1, Iterable v2) {
+  if (v1.length != v2.length) {
+    return false;
+  }
+
+  for (var i = 0; i < v1.length; i++) {
+    if (v1.elementAt(i) != v2.elementAt(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool deepEqual(dynamic v1, dynamic v2) {
+  if (v1 is Map && v2 is Map) {
+    return v1.keys.length == v2.keys.length &&
+        v1.keys.every((key) => deepEqual(v1[key], v2[key]));
+  }
+
+  if (v1 is Iterable && v2 is Iterable) {
+    return iterableEqual(v1, v2);
+  }
+
+  return v1 == v2;
+}

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -82,6 +82,10 @@ void validateDocumentValue(dynamic value) {
     // supported data types
     return;
   } else if (value is List) {
+    if (value is List<List>) {
+      throw ArgumentError.value(
+          value, null, 'Nested arrays are not supported.');
+    }
     for (final element in value) {
       validateDocumentValue(element);
     }

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -12,6 +12,7 @@ final from = (DocumentSnapshot<Map<String, dynamic>> snapshot, _) =>
     snapshot.exists ? (Movie()..title = snapshot['title']) : null;
 final to = (Movie? movie, _) =>
     movie == null ? <String, Object?>{} : {'title': movie.title};
+
 void main() {
   group('dump', () {
     const expectedDumpAfterset = '''{
@@ -614,6 +615,33 @@ void main() {
       expect(snapshot.get('previously absent'), [8, 9]);
     });
 
+    test('FieldValue.arrayUnion() should add unique Maps', () async {
+      final firestore = FakeFirebaseFirestore();
+      final docRef = firestore.collection('test').doc(uid);
+      await docRef.set({
+        'maps': [
+          {'a': 1},
+          {'b': 2}
+        ],
+      });
+
+      await docRef.update({
+        'maps': FieldValue.arrayUnion([
+          {'a': 1},
+          {'c': 3}
+        ]),
+      });
+
+      final snapshot = await docRef.get();
+      final maps = snapshot.get('maps');
+
+      expect(maps, [
+        {'a': 1},
+        {'b': 2},
+        {'c': 3}
+      ]);
+    });
+
     test('FieldValue.arrayRemove() removes items', () async {
       final firestore = FakeFirebaseFirestore();
       // Empty document before update
@@ -641,6 +669,33 @@ void main() {
       expect(snapshot.get('untouched'), [3]);
       expect(snapshot.get('previously String'), []);
       expect(snapshot.get('previously absent'), []);
+    });
+
+    test('FieldValue.arrayRemove() should remove Maps', () async {
+      final firestore = FakeFirebaseFirestore();
+      final docRef = firestore.collection('test').doc(uid);
+      await docRef.set({
+        'maps': [
+          {'a': 1},
+          {'b': 2},
+          {'c': 3},
+        ],
+      });
+
+      await docRef.update({
+        'maps': FieldValue.arrayRemove([
+          {'b': 2},
+          {'d': 4}
+        ]),
+      });
+
+      final snapshot = await docRef.get();
+      final maps = snapshot.get('maps');
+
+      expect(maps, [
+        {'a': 1},
+        {'c': 3}
+      ]);
     });
 
     test('FieldValue in nested objects', () async {

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -931,6 +931,30 @@ void main() {
     }
   });
 
+  test('Should throw Error if data contains nested list', () async {
+    final firestore = FakeFirebaseFirestore();
+    await expectLater(
+      () => firestore.collection('test').doc().set({
+        'a': [
+          [1, 2],
+          [3, 4]
+        ],
+      }),
+      throwsA(isA<Error>()),
+    );
+    await expectLater(
+      () => firestore.collection('test').doc().set({
+        'a': {
+          'b': [
+            [1, 2],
+            [3, 4]
+          ],
+        },
+      }),
+      throwsA(isA<Error>()),
+    );
+  });
+
   test('auto generate ID', () async {
     final firestore = FakeFirebaseFirestore();
     final reference1 = firestore.collection('users').doc();

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -796,6 +796,46 @@ void main() {
       // this FieldPath can't be done "a.b" style because the field has dots in it
       expect(document.get(FieldPath(['a', 'I.have.dots'])), 'c');
     });
+
+    test('Should throw StateError if field does not exist', () async {
+      final firestore = FakeFirebaseFirestore();
+      final collection = firestore.collection('test');
+      final doc = collection.doc('test');
+      await doc.set({
+        'nested': {'field': 3}
+      });
+
+      final snapshot = await doc.get();
+
+      expect(() => snapshot.get('foo'), throwsA(isA<StateError>()));
+      expect(() => snapshot.get('nested.foo'), throwsA(isA<StateError>()));
+    });
+
+    test('Should not throw StateError if value at field is null', () async {
+      final firestore = FakeFirebaseFirestore();
+      final collection = firestore.collection('test');
+      final doc = collection.doc('test');
+      await doc.set({
+        'nested': {'field': null},
+        'field': null
+      });
+
+      final snapshot = await doc.get();
+
+      expect(snapshot.get('field'), isNull);
+      expect(snapshot.get('nested.field'), isNull);
+    });
+
+    test('Should throw StateError for a.b path if a is not Map', () async {
+      final firestore = FakeFirebaseFirestore();
+      final collection = firestore.collection('test');
+      final doc = collection.doc('test');
+      await doc.set({'nested': 3});
+
+      final snapshot = await doc.get();
+
+      expect(() => snapshot.get('nested.field'), throwsA(isA<StateError>()));
+    });
   });
 
   test('set to nested docs', () async {

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -642,6 +642,27 @@ void main() {
       ]);
     });
 
+    test('FieldValue.arrayUnion() should add unique dates', () async {
+      final firestore = FakeFirebaseFirestore();
+      final docRef = firestore.collection('test').doc(uid);
+      await docRef.set({
+        'dates': [DateTime(2022, 1, 1)],
+      });
+
+      await docRef.update({
+        'dates':
+            FieldValue.arrayUnion([DateTime(2022, 1, 1), DateTime(2022, 1, 2)]),
+      });
+
+      final snapshot = await docRef.get();
+      final dates = (snapshot.get('dates') as List<dynamic>)
+          .cast<Timestamp>()
+          .map((e) => e.toDate())
+          .toList();
+
+      expect(dates, [DateTime(2022, 1, 1), DateTime(2022, 1, 2)]);
+    });
+
     test('FieldValue.arrayRemove() removes items', () async {
       final firestore = FakeFirebaseFirestore();
       // Empty document before update
@@ -696,6 +717,32 @@ void main() {
         {'a': 1},
         {'c': 3}
       ]);
+    });
+
+    test('FieldValue.arrayRemove() should remove dates', () async {
+      final firestore = FakeFirebaseFirestore();
+      final docRef = firestore.collection('test').doc(uid);
+      await docRef.set({
+        'dates': [
+          DateTime(2022, 1, 1),
+          DateTime(2022, 1, 2),
+          DateTime(2022, 1, 3),
+        ],
+      });
+
+      await docRef.update({
+        'dates': FieldValue.arrayRemove(
+          [DateTime(2022, 1, 2), DateTime(2022, 1, 4)],
+        ),
+      });
+
+      final snapshot = await docRef.get();
+      final dates = (snapshot.get('dates') as List<dynamic>)
+          .cast<Timestamp>()
+          .map((e) => e.toDate())
+          .toList();
+
+      expect(dates, [DateTime(2022, 1, 1), DateTime(2022, 1, 3)]);
     });
 
     test('FieldValue in nested objects', () async {


### PR DESCRIPTION
**Summary**
This PR aims to make this package more consistent with original by solving some of the submitted issues.
* handle maps correctly when using ```FieldValue.arrayUnion``` or ```FieldValue.arrayRemove```, fixes #194 #234. This now works with dates too, though it was not submitted.
* throw when trying to save data with nested array, fixes #113.
* throw ```StateError``` when trying to access non-existent field with ```MockDocumentSnapshot.get```, fixes #165, #169.