### PR TITLE
remove unused empty delegates

### DIFF
--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -3,11 +3,9 @@ import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:fake_cloud_firestore/src/fake_query_with_parent.dart';
 
 import 'converter.dart';
-import 'mock_collection_reference_platform.dart';
 import 'mock_document_reference.dart';
 import 'mock_query.dart';
 import 'mock_query_snapshot.dart';
@@ -26,10 +24,6 @@ class MockCollectionReference<T extends Object?> extends MockQuery<T>
 
   /// Path from the root to this collection. For example "users/USER0004/friends"
   final String _path;
-
-  // ignore: unused_field
-  final CollectionReferencePlatform _delegate =
-      MockCollectionReferencePlatform();
 
   MockCollectionReference(
     this._firestore,

--- a/lib/src/mock_collection_reference_platform.dart
+++ b/lib/src/mock_collection_reference_platform.dart
@@ -1,6 +1,0 @@
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-
-class MockCollectionReferencePlatform implements CollectionReferencePlatform {
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -7,7 +7,6 @@ import 'package:rxdart/rxdart.dart';
 import 'converter.dart';
 import 'fake_cloud_firestore_instance.dart';
 import 'mock_collection_reference.dart';
-import 'mock_document_reference_platform.dart';
 import 'mock_document_snapshot.dart';
 import 'mock_field_value_platform.dart';
 import 'query_snapshot_stream_manager.dart';
@@ -48,9 +47,6 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
       this.rootParent,
       this.snapshotStreamControllerRoot,
       this._converter);
-
-  // ignore: unused_field
-  final DocumentReferencePlatform _delegate = MockDocumentReferencePlatform();
 
   @override
   FirebaseFirestore get firestore => _firestore;

--- a/lib/src/mock_document_reference_platform.dart
+++ b/lib/src/mock_document_reference_platform.dart
@@ -1,6 +1,0 @@
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-
-class MockDocumentReferencePlatform implements DocumentReferencePlatform {
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:fake_cloud_firestore/src/fake_aggregate_query.dart';
 import 'package:fake_cloud_firestore/src/util.dart';
 import 'package:flutter/services.dart';
@@ -11,7 +10,6 @@ import 'package:quiver/core.dart';
 import 'converter.dart';
 import 'fake_converted_query.dart';
 import 'fake_query_with_parent.dart';
-import 'mock_query_platform.dart';
 import 'mock_query_snapshot.dart';
 
 typedef _QueryOperation<T extends Object?> = List<DocumentSnapshot<T>> Function(
@@ -34,11 +32,8 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
   @override
   final Map<String, dynamic> parameters;
 
-  // ignore: unused_field
-  final QueryPlatform _delegate = MockQueryPlatform();
-
   @override
-  int get hashCode => hash3(_parentQuery, _operation, _delegate);
+  int get hashCode => hash2(_parentQuery, _operation);
 
   @override
   Future<QuerySnapshot<T>> get([GetOptions? options]) async {

--- a/lib/src/mock_query_platform.dart
+++ b/lib/src/mock_query_platform.dart
@@ -1,6 +1,0 @@
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-
-class MockQueryPlatform implements QueryPlatform {
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}


### PR DESCRIPTION
I had initially added those classes because the `noSuchMethod` pattern did not exist yet (or I was simply unaware of it).

```dart
  @override
  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
```