### PR TITLE
Fix FieldValue equality

### DIFF
--- a/lib/src/mock_field_value_platform.dart
+++ b/lib/src/mock_field_value_platform.dart
@@ -97,4 +97,14 @@ class MockFieldValuePlatform
   final FakeFieldValue value;
 
   MockFieldValuePlatform(this.value);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MockFieldValuePlatform &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
 }

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -534,6 +534,16 @@ void main() {
   });
 
   group('FieldValue', () {
+    test('Equality', () {
+      // This is needed, so that the FieldValueFactoryPlatform.instance
+      // is replaced with MockFieldValueFactoryPlatform
+      FakeFirebaseFirestore();
+      expect(FieldValue.delete() == FieldValue.delete(), isTrue);
+      expect(
+          FieldValue.serverTimestamp() == FieldValue.serverTimestamp(), isTrue);
+      expect(FieldValue.delete() == FieldValue.serverTimestamp(), isFalse);
+    });
+
     test('FieldValue.delete() deletes key values', () async {
       final firestore = FakeFirebaseFirestore();
       await firestore.doc('root/foo').set({'flower': 'rose'});


### PR DESCRIPTION
Base library makes it possible to compare ```FieldValue.delete()``` and ```FieldValue.serverTimestamp()```. The moment you call ```FakeFirebaseFirestore()``` it stops working, because it overwrites global ```FieldValueFactoryPlatform.instance``` with ```MockFieldValueFactoryPlatform```.

I added a test, it's basically the same as that one:
https://github.com/firebase/flutterfire/blob/cbb24aca7b1cfb264005e069e4377710a0f7b67f/packages/cloud_firestore/cloud_firestore/test/field_value_test.dart