### PR TITLE
Handle geopoint in encoder

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -46,6 +46,11 @@ dynamic myEncode(dynamic item) {
     return item.toDate().toIso8601String();
   } else if (item is FieldValue) {
     return item.toString();
+  } else if (item is GeoPoint) {
+    return {
+      'latitude': item.latitude,
+      'longitude': item.longitude,
+    };
   }
   return item;
 }

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -18,7 +18,11 @@ void main() {
     const expectedDumpAfterset = '''{
   "users": {
     "abc": {
-      "name": "Bob"
+      "name": "Bob",
+      "location": {
+        "latitude": 35.680407336326056,
+        "longitude": 139.76917235721484
+      }
     }
   }
 }''';
@@ -27,6 +31,7 @@ void main() {
       final instance = FakeFirebaseFirestore();
       await instance.collection('users').doc(uid).set({
         'name': 'Bob',
+        'location': GeoPoint(35.680407336326056, 139.76917235721484)
       });
       expect(instance.dump(), equals(expectedDumpAfterset));
     });


### PR DESCRIPTION
Convert GeoPoint to a map so that `dump` does not crash if the fake firestore instance contains a GeoPoint object.

https://github.com/atn832/fake_cloud_firestore/issues/35