### PR TITLE
where with FieldPath.documentID and DocumentReference

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -148,7 +148,7 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
       final fieldValue = fieldValuePlatform.value;
       fieldValue.updateDocument(document, key);
     } else {
-      document[key] = transformDates(value);
+      document[key] = transformValue(value, timestampFromDateTime);
     }
   }
 

--- a/lib/src/mock_field_value_platform.dart
+++ b/lib/src/mock_field_value_platform.dart
@@ -48,7 +48,7 @@ class FieldValueIncrement extends FakeFieldValue {
 
 class FieldValueArrayUnion extends FakeFieldValue {
   FieldValueArrayUnion(List<dynamic> _elements)
-      : elements = transformDates(_elements);
+      : elements = transformValue(_elements, timestampFromDateTime);
 
   final List<dynamic> elements;
 
@@ -70,7 +70,7 @@ class FieldValueArrayUnion extends FakeFieldValue {
 
 class FieldValueArrayRemove extends FakeFieldValue {
   FieldValueArrayRemove(List<dynamic> _elements)
-      : elements = transformDates(_elements);
+      : elements = transformValue(_elements, timestampFromDateTime);
 
   final List<dynamic> elements;
 

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -243,6 +243,21 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
                 }
               } else if (field == FieldPath.documentId) {
                 value = document.id;
+
+                // transform any DocumentReference in the query to id.
+                isEqualTo = transformDocumentReference(isEqualTo);
+                isNotEqualTo = transformDocumentReference(isNotEqualTo);
+                isLessThan = transformDocumentReference(isLessThan);
+                isLessThanOrEqualTo =
+                    transformDocumentReference(isLessThanOrEqualTo);
+                isGreaterThan = transformDocumentReference(isGreaterThan);
+                isGreaterThanOrEqualTo =
+                    transformDocumentReference(isGreaterThanOrEqualTo);
+                arrayContains = transformDocumentReference(arrayContains);
+                arrayContainsAny = transformDocumentReference(arrayContainsAny);
+                whereIn = transformDocumentReference(whereIn);
+                whereNotIn = transformDocumentReference(whereNotIn);
+                isNull = transformDocumentReference(isNull);
               }
               return _valueMatchesQuery(value,
                   isEqualTo: isEqualTo,

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -229,49 +229,52 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       List<dynamic>? whereIn,
       List<dynamic>? whereNotIn,
       bool? isNull}) {
-    final operation =
-        (List<DocumentSnapshot<T>> docs) => docs.where((document) {
-              dynamic value;
-              if (field is String || field is FieldPath) {
-                // DocumentSnapshot.get can throw StateError
-                // if field cannot be found. In query it does not matter,
-                // so catch and set value to null.
-                try {
-                  value = document.get(field);
-                } on StateError catch (_) {
-                  value = null;
-                }
-              } else if (field == FieldPath.documentId) {
-                value = document.id;
+    final operation = (List<DocumentSnapshot<T>> docs) =>
+        docs.where((document) {
+          dynamic value;
+          if (field is String || field is FieldPath) {
+            // DocumentSnapshot.get can throw StateError
+            // if field cannot be found. In query it does not matter,
+            // so catch and set value to null.
+            try {
+              value = document.get(field);
+            } on StateError catch (_) {
+              value = null;
+            }
+          } else if (field == FieldPath.documentId) {
+            value = document.id;
 
-                // transform any DocumentReference in the query to id.
-                isEqualTo = transformDocumentReference(isEqualTo);
-                isNotEqualTo = transformDocumentReference(isNotEqualTo);
-                isLessThan = transformDocumentReference(isLessThan);
-                isLessThanOrEqualTo =
-                    transformDocumentReference(isLessThanOrEqualTo);
-                isGreaterThan = transformDocumentReference(isGreaterThan);
-                isGreaterThanOrEqualTo =
-                    transformDocumentReference(isGreaterThanOrEqualTo);
-                arrayContains = transformDocumentReference(arrayContains);
-                arrayContainsAny = transformDocumentReference(arrayContainsAny);
-                whereIn = transformDocumentReference(whereIn);
-                whereNotIn = transformDocumentReference(whereNotIn);
-                isNull = transformDocumentReference(isNull);
-              }
-              return _valueMatchesQuery(value,
-                  isEqualTo: isEqualTo,
-                  isNotEqualTo: isNotEqualTo,
-                  isLessThan: isLessThan,
-                  isLessThanOrEqualTo: isLessThanOrEqualTo,
-                  isGreaterThan: isGreaterThan,
-                  isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
-                  arrayContains: arrayContains,
-                  arrayContainsAny: arrayContainsAny,
-                  whereIn: whereIn,
-                  whereNotIn: whereNotIn,
-                  isNull: isNull);
-            }).toList();
+            // transform any DocumentReference in the query to id.
+            isEqualTo = transformValue(isEqualTo, documentReferenceToId);
+            isNotEqualTo = transformValue(isNotEqualTo, documentReferenceToId);
+            isLessThan = transformValue(isLessThan, documentReferenceToId);
+            isLessThanOrEqualTo =
+                transformValue(isLessThanOrEqualTo, documentReferenceToId);
+            isGreaterThan =
+                transformValue(isGreaterThan, documentReferenceToId);
+            isGreaterThanOrEqualTo =
+                transformValue(isGreaterThanOrEqualTo, documentReferenceToId);
+            arrayContains =
+                transformValue(arrayContains, documentReferenceToId);
+            arrayContainsAny =
+                transformValue(arrayContainsAny, documentReferenceToId);
+            whereIn = transformValue(whereIn, documentReferenceToId);
+            whereNotIn = transformValue(whereNotIn, documentReferenceToId);
+            isNull = transformValue(isNull, documentReferenceToId);
+          }
+          return _valueMatchesQuery(value,
+              isEqualTo: isEqualTo,
+              isNotEqualTo: isNotEqualTo,
+              isLessThan: isLessThan,
+              isLessThanOrEqualTo: isLessThanOrEqualTo,
+              isGreaterThan: isGreaterThan,
+              isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+              arrayContains: arrayContains,
+              arrayContainsAny: arrayContainsAny,
+              whereIn: whereIn,
+              whereNotIn: whereNotIn,
+              isNull: isNull);
+        }).toList();
     return MockQuery<T>(this, operation);
   }
 
@@ -288,10 +291,10 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       List<dynamic>? whereNotIn,
       bool? isNull}) {
     if (isEqualTo != null) {
-      isEqualTo = transformDates(isEqualTo);
+      isEqualTo = transformValue(isEqualTo, timestampFromDateTime);
       return value == isEqualTo;
     } else if (isNotEqualTo != null) {
-      isNotEqualTo = transformDates(isNotEqualTo);
+      isNotEqualTo = transformValue(isNotEqualTo, timestampFromDateTime);
       // requires that value is not null AND not equal to the argument
       return value != null && value != isNotEqualTo;
     } else if (isNull != null) {
@@ -302,29 +305,32 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
       if (value is! Comparable) {
         return false;
       }
-      isGreaterThan = transformDates(isGreaterThan);
+      isGreaterThan = transformValue(isGreaterThan, timestampFromDateTime);
       return value.compareTo(isGreaterThan) > 0;
     } else if (isGreaterThanOrEqualTo != null) {
       if (value is! Comparable) {
         return false;
       }
-      isGreaterThanOrEqualTo = transformDates(isGreaterThanOrEqualTo);
+      isGreaterThanOrEqualTo =
+          transformValue(isGreaterThanOrEqualTo, timestampFromDateTime);
       return value.compareTo(isGreaterThanOrEqualTo) >= 0;
     } else if (isLessThan != null) {
       if (value is! Comparable) {
         return false;
       }
-      isLessThan = transformDates(isLessThan);
+      isLessThan = transformValue(isLessThan, timestampFromDateTime);
       return value.compareTo(isLessThan) < 0;
     } else if (isLessThanOrEqualTo != null) {
       if (value is! Comparable) {
         return false;
       }
-      isLessThanOrEqualTo = transformDates(isLessThanOrEqualTo);
+      isLessThanOrEqualTo =
+          transformValue(isLessThanOrEqualTo, timestampFromDateTime);
       return value.compareTo(isLessThanOrEqualTo) <= 0;
     } else if (arrayContains != null) {
       if (value is Iterable) {
-        return value.contains(transformDates(arrayContains));
+        return value
+            .contains(transformValue(arrayContains, timestampFromDateTime));
       } else {
         return false;
       }
@@ -345,7 +351,8 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
         );
       }
       if (value is Iterable) {
-        arrayContainsAny = transformDates(arrayContainsAny) as List;
+        arrayContainsAny =
+            transformValue(arrayContainsAny, timestampFromDateTime) as List;
         var valueSet = Set.from(value);
         for (var elem in arrayContainsAny) {
           if (valueSet.contains(elem)) {
@@ -367,7 +374,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
           'whereIn cannot be combined with arrayContainsAny',
         );
       }
-      whereIn = transformDates(whereIn) as List;
+      whereIn = transformValue(whereIn, timestampFromDateTime) as List;
       if (whereIn.contains(value)) {
         return true;
       }
@@ -383,7 +390,7 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
           'whereNotIn cannot be combined with arrayContainsAny',
         );
       }
-      whereNotIn = transformDates(whereNotIn) as List;
+      whereNotIn = transformValue(whereNotIn, timestampFromDateTime) as List;
       if (whereNotIn.contains(value)) {
         return false;
       }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -121,6 +121,22 @@ dynamic transformDates(dynamic value) {
   return value;
 }
 
+/// Extract the id from DocumentReference.
+/// Handles complex structures like Map and List
+/// by recursively calling itself on each entry.
+dynamic transformDocumentReference(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value.map((k, v) => MapEntry(k, transformDates(v)));
+  }
+  if (value is Iterable) {
+    return value.map((e) => transformDocumentReference(e)).toList();
+  }
+  if (value is DocumentReference) {
+    return value.id;
+  }
+  return value;
+}
+
 /// Convenience method for comparison of collections, e.g. Lists, Maps.
 bool deepEqual(dynamic v1, dynamic v2) {
   return DeepCollectionEquality().equals(v1, v2);

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -105,32 +105,32 @@ void validateDocumentValue(dynamic value) {
   throw ArgumentError.value(value);
 }
 
-/// Converts DateTime to Timestamp.
-/// Handles complex structures like Map and List
-/// by recursively calling itself on each entry.
-dynamic transformDates(dynamic value) {
+/// Transforms a non-recursive value.
+typedef TransformSimpleValue = dynamic Function(dynamic simpleValue);
+
+/// Transform a value recursively.
+dynamic transformValue(
+    dynamic value, TransformSimpleValue transformSimpleValue) {
   if (value is Map<String, dynamic>) {
-    return value.map((k, v) => MapEntry(k, transformDates(v)));
+    return value
+        .map((k, v) => MapEntry(k, transformValue(v, transformSimpleValue)));
   }
   if (value is Iterable) {
-    return value.map((e) => transformDates(e)).toList();
+    return value.map((e) => transformValue(e, transformSimpleValue)).toList();
   }
+  return transformSimpleValue(value);
+}
+
+/// Transform [DateTime] to [Timestamp], other types are returned as is.
+dynamic timestampFromDateTime(dynamic value) {
   if (value is DateTime) {
     return Timestamp.fromDate(value);
   }
   return value;
 }
 
-/// Extract the id from DocumentReference.
-/// Handles complex structures like Map and List
-/// by recursively calling itself on each entry.
-dynamic transformDocumentReference(dynamic value) {
-  if (value is Map<String, dynamic>) {
-    return value.map((k, v) => MapEntry(k, transformDocumentReference(v)));
-  }
-  if (value is Iterable) {
-    return value.map((e) => transformDocumentReference(e)).toList();
-  }
+/// Transform [DocumentReference] to id [String], other types are returned as is.
+dynamic documentReferenceToId(dynamic value) {
   if (value is DocumentReference) {
     return value.id;
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -126,7 +126,7 @@ dynamic transformDates(dynamic value) {
 /// by recursively calling itself on each entry.
 dynamic transformDocumentReference(dynamic value) {
   if (value is Map<String, dynamic>) {
-    return value.map((k, v) => MapEntry(k, transformDates(v)));
+    return value.map((k, v) => MapEntry(k, transformDocumentReference(v)));
   }
   if (value is Iterable) {
     return value.map((e) => transformDocumentReference(e)).toList();

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -615,6 +615,24 @@ void main() {
     expect(documents.first.id, equals('1'));
   });
 
+  test('where with FieldPath.documentID and DocumentReference', () async {
+    final instance = FakeFirebaseFirestore();
+    await instance.collection('users').doc('1').set({'value': 1});
+    await instance.collection('users').doc('2').set({'value': 2});
+    await instance.collection('users').doc('3').set({'value': 3});
+
+    final snapshot = await instance
+        .collection('users')
+        .where(FieldPath.documentId,
+            isEqualTo: instance.collection('users').doc('1'))
+        .get();
+
+    final documents = snapshot.docs;
+
+    expect(documents.length, equals(1));
+    expect(documents.first.id, equals('1'));
+  });
+
   test('Collection.getDocuments', () async {
     final instance = FakeFirebaseFirestore();
     await instance.collection('users').add({


### PR DESCRIPTION
Fix:
`FieldPath.documentID` should be matched against `DocumentReference`.
