### PR TITLE
fix: streamController nullcheck to prevent `ConcurrentModificationError`

### DIFF
--- a/lib/src/query_snapshot_stream_manager.dart
+++ b/lib/src/query_snapshot_stream_manager.dart
@@ -88,8 +88,11 @@ class QuerySnapshotStreamManager {
     }
     final exactPathCache = _streamCache[firestore]![path];
     if (exactPathCache != null) {
-      for (final query in exactPathCache.keys) {
-        await query.get().then(exactPathCache[query]!.add);
+      for (final query in exactPathCache.keys.toList()) {
+        final streamController = exactPathCache[query];
+        if (streamController != null) {
+          await query.get().then(streamController.add);
+        }
       }
     }
 


### PR DESCRIPTION
Introduces a null check on `streamController` in `query_snapshot_stream_manager.dart`, which prevents a `ConcurrentModificationError` occurring. I discovered this error while writing a test which utilized three separate create, update, and delete batch commits on the same collcection.