### PR TITLE
fixed where query without any parameters

### DIFF
--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -400,6 +400,18 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
         return false;
       }
       return true;
+    } else if (isEqualTo == null &&
+        isNotEqualTo == null &&
+        isLessThan == null &&
+        isLessThanOrEqualTo == null &&
+        isGreaterThan == null &&
+        isGreaterThanOrEqualTo == null &&
+        arrayContains == null &&
+        arrayContainsAny == null &&
+        whereIn == null &&
+        whereNotIn == null &&
+        isNull == null) {
+      return true;
     }
     throw 'Unsupported';
   }


### PR DESCRIPTION
changed in PR.
* fixed where query without any parameters

--- 

i want to query without any parameters. 

in my case.. 

i used firebase database query with optional parameters.
~~~dart
Future<dynamic> listPost({String? writerId}) {
  return _myPostCollection
      .where('writerId', isEqualTo: writerId)
      .get();
}
~~~

i will get all post function in "test code" without any parameters.
~~~dart
/// test code
final posts = await postRepositiry.listPost();
expect(posts.isNotEmpty, equals(true));
~~~
above code, i will expect get list of post.
but, occurs `Unsupported ` Error. 


~~~dart
final posts = await postRepositiry.listPost(writerId: 'userId-1');
~~~
it's working when with parameters. 

---