### PR TITLE
Implement `clearPersistence` to wipe fake database

### DIFF
--- a/lib/src/fake_cloud_firestore_instance.dart
+++ b/lib/src/fake_cloud_firestore_instance.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
     as firestore_interface;
+import 'package:fake_cloud_firestore/src/query_snapshot_stream_manager.dart';
 import 'package:fake_firebase_security_rules/fake_firebase_security_rules.dart';
 import 'package:flutter/services.dart';
 import 'package:rxdart/rxdart.dart';
@@ -104,6 +105,16 @@ class FakeFirebaseFirestore implements FirebaseFirestore {
       int maxAttempts = 5}) async {
     Transaction transaction = _DummyTransaction();
     return await transactionHandler(transaction);
+  }
+
+  /// Wipes entire fake database.
+  @override
+  Future<void> clearPersistence() {
+    _root.clear();
+    _docsData.clear();
+    _snapshotStreamControllerRoot.clear();
+    _savedDocumentPaths.clear();
+    return QuerySnapshotStreamManager().clear();
   }
 
   String dump() {

--- a/lib/src/fake_query_with_parent.dart
+++ b/lib/src/fake_query_with_parent.dart
@@ -25,7 +25,15 @@ abstract class FakeQueryWithParent<T extends Object?> implements Query<T> {
     QuerySnapshotStreamManager().register<T>(this);
     final controller =
         QuerySnapshotStreamManager().getStreamController<T>(this);
-    controller.addStream(Stream.fromFuture(get()));
+    get().then((event) {
+      if (controller.isClosed == false) {
+        controller.add(event);
+      }
+    }, onError: (error) {
+      if (controller.isClosed == false) {
+        controller.addError(error);
+      }
+    });
     return controller.stream.distinct(_snapshotEquals);
   }
 

--- a/lib/src/query_snapshot_stream_manager.dart
+++ b/lib/src/query_snapshot_stream_manager.dart
@@ -19,16 +19,18 @@ class QuerySnapshotStreamManager {
               Map<FakeQueryWithParent, StreamController<QuerySnapshot>>>>
       _streamCache = {};
 
-  void clear() {
+  Future<void> clear() {
+    final streamCloseFutures = <Future>[];
     for (final pathToQueryToStreamController in _streamCache.values) {
       for (final queryToStreamController
           in pathToQueryToStreamController.values) {
         for (final streamController in queryToStreamController.values) {
-          streamController.close();
+          streamCloseFutures.add(streamController.close());
         }
       }
     }
     _streamCache.clear();
+    return Future.wait(streamCloseFutures);
   }
 
   /// Recursively finds the base collection path.

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -1695,6 +1695,18 @@ void main() {
           completes);
     });
   });
+
+  group('clearPersistence()', () {
+    test('Should clear fake persistence database', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.doc('foo/foo_1/bar/bar_1').set({'value': '1'});
+      await firestore.clearPersistence();
+      expect(
+        firestore.collectionGroup('bar').snapshots(),
+        emits(QuerySnapshotMatcher([])),
+      );
+    });
+  });
 }
 
 class Movie {


### PR DESCRIPTION
Changes:

- Added `clearPersistence()` implementation to clear fake cloud firestore

