### PR TITLE
fix: increased limit `whereIn` and `arrayContainsAny` disjunctions

### DIFF
--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -340,9 +340,9 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
         return false;
       }
     } else if (arrayContainsAny != null) {
-      if (arrayContainsAny.length > 10) {
+      if (arrayContainsAny.length > 30) {
         throw ArgumentError(
-          'arrayContainsAny cannot contain more than 10 comparison values',
+          'arrayContainsAny cannot contain more than 30 comparison values',
         );
       }
       if (whereIn != null) {
@@ -369,9 +369,9 @@ class MockQuery<T extends Object?> extends FakeQueryWithParent<T> {
         return false;
       }
     } else if (whereIn != null) {
-      if (whereIn.length > 10) {
+      if (whereIn.length > 30) {
         throw ArgumentError(
-          'whereIn cannot contain more than 10 comparison values',
+          'whereIn cannot contain more than 30 comparison values',
         );
       }
       if (arrayContainsAny != null) {

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -474,7 +474,7 @@ void main() {
         .collection('posts')
         .where(
           'commenters',
-          arrayContainsAny: toIterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+          arrayContainsAny: Iterable.generate(31, (index) => index),
         )
         .snapshots()
         .listen(null, onError: expectAsync1((error) {
@@ -517,9 +517,7 @@ void main() {
         .collection('contestants')
         .where(
           'country',
-          whereIn: toIterable(
-            ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'],
-          ),
+          whereIn: Iterable.generate(31, (index) => 'A_$index'),
         )
         .snapshots()
         .listen(null, onError: expectAsync1((error) {


### PR DESCRIPTION
Increased limit on `whereIn` and `arrayContainsAny` queries per updated Firestore docs: 

https://firebase.google.com/docs/firestore/query-data/queries#limitations_2