### PR TITLE
Feature/fix aggregate issue with converted queries

### DIFF
--- a/lib/src/aggregate_type_extension.dart
+++ b/lib/src/aggregate_type_extension.dart
@@ -1,0 +1,16 @@
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+
+extension AggregateTypeExtension on AggregateType {
+  Type get aggregateFieldType {
+    switch (this) {
+      case AggregateType.sum:
+        return sum;
+      case AggregateType.average:
+        return average;
+      case AggregateType.count:
+        return count;
+      default:
+        throw UnimplementedError('Unknown AggregateType: $this');
+    }
+  }
+}

--- a/lib/src/fake_aggregate_query.dart
+++ b/lib/src/fake_aggregate_query.dart
@@ -4,6 +4,8 @@ import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
     as platform_interface;
 import 'package:collection/collection.dart';
+import 'package:fake_cloud_firestore/src/mock_document_snapshot.dart';
+import 'package:fake_cloud_firestore/src/mock_query_document_snapshot.dart';
 import 'package:flutter/foundation.dart';
 
 import 'fake_aggregate_query_snapshot.dart';
@@ -28,10 +30,18 @@ class FakeAggregateQuery implements AggregateQuery {
   @override
   AggregateQuery count() => _query.count();
 
+  Map<String, dynamic> _getRawDocDataMap(QueryDocumentSnapshot<Object?> s) {
+    if (s is MockQueryDocumentSnapshot && s.snapshot is MockDocumentSnapshot) {
+      return (s.snapshot as MockDocumentSnapshot).getRawDocument();
+    }
+    // this line should never execute but leave it here to play safe.
+    return s.data() as Map<String, dynamic>;
+  }
+
   AggregateQuerySnapshotPlatform _getAggregateQuerySnapshotPlatform({
     required QuerySnapshot<Object?> snapshot,
   }) {
-    final dataMaps = snapshot.docs.map((e) => e.data() as Map<String, dynamic>);
+    final dataMaps = snapshot.docs.map((s) => _getRawDocDataMap(s));
     final delegate = AggregateQuerySnapshotPlatform(
       count: snapshot.size,
       sum: buildAggregateQueryResponseList(

--- a/lib/src/fake_aggregate_query.dart
+++ b/lib/src/fake_aggregate_query.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
     as platform_interface;
 import 'package:collection/collection.dart';
+import 'package:fake_cloud_firestore/src/aggregate_type_extension.dart';
 import 'package:fake_cloud_firestore/src/mock_document_snapshot.dart';
 import 'package:fake_cloud_firestore/src/mock_query_document_snapshot.dart';
 import 'package:flutter/foundation.dart';
@@ -77,17 +78,9 @@ class FakeAggregateQuery implements AggregateQuery {
     required Iterable<AggregateField?> fields,
     required AggregateType type,
   }) {
-    final nonNullFields = fields.whereNotNull();
-    switch (type) {
-      case AggregateType.sum:
-        return nonNullFields.whereType<platform_interface.sum>();
-      case AggregateType.average:
-        return nonNullFields.whereType<platform_interface.average>();
-      case AggregateType.count:
-        return nonNullFields.whereType<platform_interface.count>();
-      default:
-        throw UnimplementedError('Unknown AggregateType: $type');
-    }
+    return fields
+        .whereNotNull()
+        .where((e) => e.runtimeType == type.aggregateFieldType);
   }
 
   @visibleForTesting

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -87,6 +87,4 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
 
   @override
   dynamic operator [](field) => get(field);
-
-  Map<String, dynamic> getRawDocument() => _rawDocument!;
 }

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -87,4 +87,6 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
 
   @override
   dynamic operator [](field) => get(field);
+
+  Map<String, dynamic> getRawDocument() => _rawDocument!;
 }

--- a/test/src/fake_aggregate_query_test.dart
+++ b/test/src/fake_aggregate_query_test.dart
@@ -50,6 +50,28 @@ void main() {
       });
     });
 
+    group('getAggregateFieldName', () {
+      test('should returns field name for AggregateField sum', () {
+        final field = sum('apple');
+        final fieldName = FakeAggregateQuery.getAggregateFieldName(field);
+        expect(fieldName, 'apple');
+      });
+
+      test('should returns field name for AggregateField average', () {
+        final field = average('cherry');
+        final fieldName = FakeAggregateQuery.getAggregateFieldName(field);
+        expect(fieldName, 'cherry');
+      });
+
+      test('should throw for unsupported AggregateField like count', () {
+        final field = count();
+        expect(
+          () => FakeAggregateQuery.getAggregateFieldName(field),
+          throwsUnimplementedError,
+        );
+      });
+    });
+
     group('buildAggregateQueryResponseList', () {
       test(
           'should returns list of AggregateQueryResponse with sum type from maps and fields',

--- a/test/src/fake_aggregate_query_test.dart
+++ b/test/src/fake_aggregate_query_test.dart
@@ -1,9 +1,30 @@
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:fake_cloud_firestore/src/fake_aggregate_query.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('FakeAggregateQuery', () {
+    late FakeFirebaseFirestore firestore;
+
+    setUpAll(() {
+      firestore = FakeFirebaseFirestore();
+    });
+
+    tearDownAll(() {
+      firestore.clearPersistence();
+    });
+
+    setUp(() {
+      final collection = firestore.collection('my_shops');
+      collection.add({'shopId': '001', 'apple': 18, 'banana': 23});
+      collection.add({'shopId': '002', 'apple': 12, 'banana': 34});
+    });
+
+    tearDown(() {
+      firestore.clearPersistence();
+    });
+
     group('convertValuesMapToResponseList', () {
       test('should returns list of AggregateQueryResponse from map', () {
         final keyNumMap = <String, double>{
@@ -32,17 +53,14 @@ void main() {
     group('buildAggregateQueryResponseList', () {
       test(
           'should returns list of AggregateQueryResponse with sum type from maps and fields',
-          () {
-        final dataMaps = [
-          {'shopId': '001', 'apple': 18, 'banana': 23},
-          {'shopId': '002', 'apple': 12, 'banana': 34},
-        ];
+          () async {
+        final querySnapshot = await firestore.collection('my_shops').get();
         final aggregateFields = [
           sum('apple'),
           sum('banana'),
         ];
         final result = FakeAggregateQuery.buildAggregateQueryResponseList(
-          dataMaps: dataMaps,
+          documentSnapshots: querySnapshot.docs,
           aggregateFields: aggregateFields,
           aggregateType: AggregateType.sum,
         );
@@ -62,17 +80,14 @@ void main() {
 
       test(
           'should returns list of AggregateQueryResponse with average type from maps and fields',
-          () {
-        final dataMaps = [
-          {'shopId': '001', 'apple': 18, 'banana': 23},
-          {'shopId': '002', 'apple': 12, 'banana': 34},
-        ];
+          () async {
+        final querySnapshot = await firestore.collection('my_shops').get();
         final aggregateFields = [
           average('apple'),
           average('banana'),
         ];
         final result = FakeAggregateQuery.buildAggregateQueryResponseList(
-          dataMaps: dataMaps,
+          documentSnapshots: querySnapshot.docs,
           aggregateFields: aggregateFields,
           aggregateType: AggregateType.average,
         );


### PR DESCRIPTION
This PR has fixed the aggregate query problem on converted queries.
https://github.com/atn832/fake_cloud_firestore/pull/290#discussion_r1445569625
The error log would be like:
```log
type 'Movie' is not a subtype of type 'Map<String, dynamic>' in type cast
package:fake_cloud_firestore/src/fake_aggregate_query.dart 34:56   FakeAggregateQuery._getAggregateQuerySnapshotPlatform.<fn>
dart:_internal                                                     ListIterator.moveNext
package:fake_cloud_firestore/src/fake_aggregate_query.dart 107:27  FakeAggregateQuery.buildAggregateQueryResponseList
package:fake_cloud_firestore/src/fake_aggregate_query.dart 37:12   FakeAggregateQuery._getAggregateQuerySnapshotPlatform
package:fake_cloud_firestore/src/fake_aggregate_query.dart 21:22   FakeAggregateQuery.get
```