### PR TITLE
fix dart-format workflow: upgrade dart image

### DIFF
--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: library/dart:latest
+      image: dart:latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:latest
+      image: google/dart:stable
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:3
+      image: google/dart:beta
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:beta
+      image: library/dart:latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -11,7 +11,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:stable
+      image: google/dart:3
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I had not realized that the google/dart Docker account had been discontinued: https://hub.docker.com/r/google/dart/tags. It was shipping with Dart 2.15.1 and couldn't parse our newer Dart 3.0.0 code.

https://github.com/atn832/fake_cloud_firestore/actions/runs/7519020088/job/20467064770
> DART_VERSION=2.15.1

The new account is https://hub.docker.com/_/dart.