### PR TITLE
fix: compatibility for listeners with different converters

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,8 +10,5 @@ include: package:pedantic/analysis_options.yaml
 #     - camel_case_types
 
 analyzer:
-  errors:
-    # TODO(https://github.com/atn832/cloud_firestore_mocks/issues/157): remove this exception when the null-safe update to flutter_driver is released (Flutter 2.10).
-    import_of_legacy_library_into_null_safe: ignore
 #   exclude:
 #     - path/to/excluded/files/**

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,4 +1,1 @@
 analyzer:
-  errors:
-    # TODO(https://github.com/atn832/cloud_firestore_mocks/issues/157): remove this exception when the null-safe update to flutter_driver is released (Flutter 2.10).
-    import_of_legacy_library_into_null_safe: ignore

--- a/lib/src/query_snapshot_stream_manager.dart
+++ b/lib/src/query_snapshot_stream_manager.dart
@@ -101,6 +101,8 @@ class QuerySnapshotStreamManager {
     if (exactPathCache != null && id != null) {
       for (final query in [...exactPathCache.keys]) {
         if (query is! FakeQueryWithParent<T>) {
+          // Backward compatibility for queries with different converters.
+          await query.get().then(exactPathCache[query]!.add);
           continue;
         }
 

--- a/test/query_snapshot_stream_manager_test.dart
+++ b/test/query_snapshot_stream_manager_test.dart
@@ -60,7 +60,7 @@ void main() {
       collectionRef = instance.collection('users');
     });
 
-    void validate() {
+    void validateSnapshotsWithoutConverter() {
       expect(
         collectionRef.snapshots(),
         emitsInOrder(
@@ -83,13 +83,10 @@ void main() {
         'name': 'Bob',
       });
 
-      validate();
-
-      await pumpEventQueue();
+      validateSnapshotsWithoutConverter();
       await collectionRef.doc('1').set({
         'name': 'Marie',
       });
-      await pumpEventQueue();
     });
     test('can receive updates starting with converter', () async {
       final converterRef = collectionRef.withConverter<User>(
@@ -98,29 +95,24 @@ void main() {
       );
       await converterRef.doc('1').set(User('Bob'));
 
-      validate();
+      validateSnapshotsWithoutConverter();
 
-      await pumpEventQueue();
       await collectionRef.doc('1').set({
         'name': 'Marie',
       });
-      await pumpEventQueue();
     });
     test('can receive updates from converter', () async {
       await collectionRef.doc('1').set({
         'name': 'Bob',
       });
 
-      await pumpEventQueue();
-
-      validate();
+      validateSnapshotsWithoutConverter();
 
       final converterRef = collectionRef.withConverter<User>(
         fromFirestore: (snapshot, options) => User.fromMap(snapshot.data()!),
         toFirestore: (user, options) => user.toFirestore(),
       );
       await converterRef.doc('1').set(User('Marie'));
-      await pumpEventQueue();
     });
   });
 }

--- a/test/query_snapshot_stream_manager_test.dart
+++ b/test/query_snapshot_stream_manager_test.dart
@@ -2,37 +2,125 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:fake_cloud_firestore/src/mock_query_snapshot.dart';
 import 'package:test/test.dart';
+
+class User {
+  final String name;
+
+  User(this.name);
+
+  User.fromMap(Map<String, dynamic> map) : name = map['name'];
+
+  Map<String, dynamic> toFirestore() => {
+        'name': name,
+      };
+}
 
 void main() {
   late FakeFirebaseFirestore instance;
 
   setUp(() async {
     instance = FakeFirebaseFirestore();
-    await instance.collection('users').add({
-      'name': 'Bob',
+  });
+
+  group('cache modifications', () {
+    setUp(() async {
+      await instance.collection('users').add({
+        'name': 'Bob',
+      });
+      await instance.collection('users').add({
+        'name': 'Marie',
+      });
     });
-    await instance.collection('users').add({
-      'name': 'Marie',
+
+    test('Should allow concurrent cache modifications', () {
+      final subscriptions = <StreamSubscription<QuerySnapshot>>[];
+      instance
+          .collection('users')
+          .snapshots()
+          .listen((QuerySnapshot<Map<String, dynamic>> snapshot) {
+        // Add a new listener to the same query while an update being fired. This
+        // used to trigger a concurrency error.
+        subscriptions.add(instance
+            .collection('users')
+            .snapshots()
+            .listen((QuerySnapshot<Map<String, dynamic>> snapshot) {}));
+      });
+      // Fire a snapshot update.
+      instance.collection('users').add({
+        'name': 'Steve',
+      });
     });
   });
 
-  test('Should allow concurrent cache modifications', () {
-    final subscriptions = <StreamSubscription<QuerySnapshot>>[];
-    instance
-        .collection('users')
-        .snapshots()
-        .listen((QuerySnapshot<Map<String, dynamic>> snapshot) {
-      // Add a new listener to the same query while an update being fired. This
-      // used to trigger a concurrency error.
-      subscriptions.add(instance
-          .collection('users')
-          .snapshots()
-          .listen((QuerySnapshot<Map<String, dynamic>> snapshot) {}));
+  group('listener updates', () {
+    late CollectionReference collectionRef;
+    setUp(() {
+      collectionRef = instance.collection('users');
     });
-    // Fire a snapshot update.
-    instance.collection('users').add({
-      'name': 'Steve',
+
+    void validate() {
+      expect(
+        collectionRef.snapshots(),
+        emitsInOrder(
+          [
+            isA<MockQuerySnapshot<Map<String, dynamic>>>().having(
+                (event) => (event.docs.first.data() as Map)['name'],
+                'has correct name',
+                'Bob'),
+            isA<MockQuerySnapshot<Map<String, dynamic>>>().having(
+                (event) => (event.docs.first.data() as Map)['name'],
+                'has correct name',
+                'Marie'),
+          ],
+        ),
+      );
+    }
+
+    test('can receive updates', () async {
+      await collectionRef.doc('1').set({
+        'name': 'Bob',
+      });
+
+      validate();
+
+      await pumpEventQueue();
+      await collectionRef.doc('1').set({
+        'name': 'Marie',
+      });
+      await pumpEventQueue();
+    });
+    test('can receive updates starting with converter', () async {
+      final converterRef = collectionRef.withConverter<User>(
+        fromFirestore: (snapshot, options) => User.fromMap(snapshot.data()!),
+        toFirestore: (user, options) => user.toFirestore(),
+      );
+      await converterRef.doc('1').set(User('Bob'));
+
+      validate();
+
+      await pumpEventQueue();
+      await collectionRef.doc('1').set({
+        'name': 'Marie',
+      });
+      await pumpEventQueue();
+    });
+    test('can receive updates from converter', () async {
+      await collectionRef.doc('1').set({
+        'name': 'Bob',
+      });
+
+      await pumpEventQueue();
+
+      validate();
+
+      final converterRef = collectionRef.withConverter<User>(
+        fromFirestore: (snapshot, options) => User.fromMap(snapshot.data()!),
+        toFirestore: (user, options) => user.toFirestore(),
+      );
+      await converterRef.doc('1').set(User('Marie'));
+      await pumpEventQueue();
     });
   });
 }


### PR DESCRIPTION
## Why?
Snapshot listeners built with a converter will not hear updates made from a reference without a converter
Fixes #294 

## What?

Re added the previous code we had before #284 when the query type doesn't match, I couldn't think of a better solution but I'm open to ideas.