### PR TITLE
fix: composite key query on null document

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -29,7 +29,7 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
 
   @override
   dynamic get(dynamic key) {
-    if (_isCompositeKey(key)) {
+    if (_isCompositeKey(key) && _rawDocument != null) {
       return _getCompositeKeyValue(key);
     }
     if (!_exists || _rawDocument?.containsKey(key) != true) {
@@ -75,7 +75,10 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
   dynamic _getCompositeKeyValue(dynamic key) {
     final compositeKeyElements =
         key is String ? key.split('.') : (key as FieldPath).components;
-    dynamic value = _rawDocument!;
+    dynamic value = _rawDocument;
+    if (value == null) {
+      return null;
+    }
     for (final keyElement in compositeKeyElements) {
       if (!(value is Map) || !value.containsKey(keyElement)) {
         throw StateError('Cannot get field that does not exist');

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1836,4 +1836,37 @@ void main() {
     });
     await db.collection('docs').doc('1').delete();
   });
+
+  test('Should query with composite key on empty content document', () async {
+    final db = FakeFirebaseFirestore();
+
+    final expectedEmitOrder = [
+      // beginning
+      [],
+      // after adding doc 1
+      ['Norman'],
+    ];
+
+    /// Create an empty document
+    await db.collection('docs').doc('1').set(<String, dynamic>{});
+
+    expect(
+      // Query with composite key
+      db
+          .collection('docs')
+          .where('traits.name', isEqualTo: 'Norman')
+          .snapshots()
+          .map((event) {
+        return event.docs.map((e) => e.get('traits.name')).toList();
+      }),
+      emitsInOrder(expectedEmitOrder),
+    );
+
+    /// Update the document to have the content
+    await db.collection('docs').doc('1').set(<String, dynamic>{
+      'traits': {
+        'name': 'Norman',
+      },
+    });
+  });
 }


### PR DESCRIPTION
Fixes null check operation on null value when queried with composite keys on null data document.

Fix for: #297 