### PR TITLE
fix: set({}) followed by get() returns {}

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -112,6 +112,13 @@ class MockDocumentReference<T extends Object?>
   /// Sets document raw data. Does not check for existence.
   Future<void> _setRawData(Map<Object, Object?> data) async {
     validateDocumentValue(data);
+
+    // If docsData does not have a Map for _path, create it. It should be
+    // created regardless of whether data contains data or not.
+    if (!docsData.containsKey(_path)) {
+      docsData[_path] = <String, dynamic>{};
+    }
+
     // Copy data so that subsequent change to `data` should not affect the data
     // stored in mock document.
     final copy = deepCopy(data);
@@ -175,9 +182,8 @@ class MockDocumentReference<T extends Object?>
 
   Map<String, dynamic> _findNestedDocumentToUpdate(String key) {
     final compositeKeyElements = key.split('.');
-    if (!docsData.containsKey(_path)) {
-      docsData[_path] = <String, dynamic>{};
-    }
+    // An empty map has previously been created by _setRawData, so
+    // docsData[_path] is guaranteed to return a Map.
     if (compositeKeyElements.length == 1) {
       // This is not a composite key
       return docsData[_path];

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -29,7 +29,7 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
 
   @override
   dynamic get(dynamic key) {
-    if (_isCompositeKey(key) && _rawDocument != null) {
+    if (_isCompositeKey(key)) {
       return _getCompositeKeyValue(key);
     }
     if (!_exists || _rawDocument?.containsKey(key) != true) {
@@ -75,10 +75,7 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
   dynamic _getCompositeKeyValue(dynamic key) {
     final compositeKeyElements =
         key is String ? key.split('.') : (key as FieldPath).components;
-    dynamic value = _rawDocument;
-    if (value == null) {
-      return null;
-    }
+    dynamic value = _rawDocument!;
     for (final keyElement in compositeKeyElements) {
       if (!(value is Map) || !value.containsKey(keyElement)) {
         throw StateError('Cannot get field that does not exist');

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -91,6 +91,23 @@ void main() {
       await doc.update({'name': 'Chris'});
       expect((await doc.get()).get('name'), equals('Chris'));
     });
+
+    test('docReference.set({}) followed by docReference.get() should return {}',
+        () async {
+      final instance = FakeFirebaseFirestore();
+
+      /// Create an empty document
+      final documentReference = instance.collection('docs').doc('1');
+      await documentReference.set(<String, dynamic>{});
+      expect((await documentReference.get()).data(), isEmpty);
+
+      /// Set empty content to a composite key.
+      await documentReference.set(<String, dynamic>{
+        'traits': {'name': {}},
+      });
+      expect((await documentReference.get()).get('traits.name'), isEmpty);
+    });
+
     test('DocumentReference.set throws exceptions', () async {
       final instance = FakeFirebaseFirestore();
       final doc = instance.collection('users').doc(uid);


### PR DESCRIPTION
Fixes #156 