### PR TITLE
Fixed exception when dump() dumps Document Reference

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -51,6 +51,8 @@ dynamic myEncode(dynamic item) {
       'latitude': item.latitude,
       'longitude': item.longitude,
     };
+  } else if (item is DocumentReference) {
+    return item.path;
   }
   return item;
 }


### PR DESCRIPTION
When database document contains document reference, Exception will occur [here](https://github.com/atn832/fake_cloud_firestore/blob/6164f7f0e9b28ee41853cd6859d8faba4a7f130f/lib/src/fake_cloud_firestore_instance.dart#L149)

Error thrown is this: 
`
JsonUnsupportedObjectError (Converting object did not return an encodable object: Instance of 'MockDocumentReference<Map<String, dynamic>>')
`
I fixed it by supporting DocumentReference type in myEncode util function.