### PR TITLE
Add source argument to support cloud_firestore 4.17.0

### DIFF
--- a/lib/src/fake_query_with_parent.dart
+++ b/lib/src/fake_query_with_parent.dart
@@ -21,7 +21,10 @@ abstract class FakeQueryWithParent<T extends Object?> implements Query<T> {
   }
 
   @override
-  Stream<QuerySnapshot<T>> snapshots({bool includeMetadataChanges = false}) {
+  Stream<QuerySnapshot<T>> snapshots({
+    bool includeMetadataChanges = false,
+    ListenSource? source,
+  }) {
     QuerySnapshotStreamManager().register<T>(this);
     final controller =
         QuerySnapshotStreamManager().getStreamController<T>(this);

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -296,7 +296,10 @@ class MockDocumentReference<T extends Object?>
   }
 
   @override
-  Stream<DocumentSnapshot<T>> snapshots({bool includeMetadataChanges = false}) {
+  Stream<DocumentSnapshot<T>> snapshots({
+    bool includeMetadataChanges = false,
+    ListenSource? source,
+  }) {
     return snapshotStreamController.stream.startWith(_getSync());
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^4.15.9
-  cloud_firestore_platform_interface: ^6.1.10
+  cloud_firestore: ^4.17.0
+  cloud_firestore_platform_interface: ^6.2.0
   collection: ^1.14.13
   plugin_platform_interface: ^2.0.0
   quiver: ^3.0.0


### PR DESCRIPTION
Add the missing `source` argument added in Firebase 4.17.0

Fixes #305