### PR TITLE
fix: multiple docs change for parallel saved doc snapshots

### DIFF
--- a/lib/src/query_snapshot_stream_manager.dart
+++ b/lib/src/query_snapshot_stream_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:collection/collection.dart';
 import 'package:rxdart/rxdart.dart';
 
 import 'fake_query_with_parent.dart';
@@ -131,6 +132,21 @@ class QuerySnapshotStreamManager {
         if (docChange != null) {
           documentsChange.add(docChange);
         }
+
+        /// When multiple new doc snapshots added for the current state, we need to fire multiple document changes
+        final newDocsChanges = docsCurrent.where((doc) {
+          return doc.id != id && docsPrior.none((element) => element.id == doc.id);
+        }).map((doc) {
+          return _getDocumentChange<T>(
+            id: doc.id,
+            docsPrior: docsPrior,
+            docsCurrent: docsCurrent,
+          );
+        });
+        if (newDocsChanges.isNotEmpty) {
+          documentsChange.addAll(newDocsChanges.whereNotNull());
+        }
+
         final querySnapshotCurrent = MockQuerySnapshot<T>(
           docsCurrent,
           querySnapshot.metadata.isFromCache,

--- a/lib/src/query_snapshot_stream_manager.dart
+++ b/lib/src/query_snapshot_stream_manager.dart
@@ -135,7 +135,8 @@ class QuerySnapshotStreamManager {
 
         /// When multiple new doc snapshots added for the current state, we need to fire multiple document changes
         final newDocsChanges = docsCurrent.where((doc) {
-          return doc.id != id && docsPrior.none((element) => element.id == doc.id);
+          return doc.id != id &&
+              docsPrior.none((element) => element.id == doc.id);
         }).map((doc) {
           return _getDocumentChange<T>(
             id: doc.id,

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1870,7 +1870,8 @@ void main() {
     });
   });
 
-  test('Should properly emit document type change on batch async save', () async {
+  test('Should properly emit document type change on batch async save',
+      () async {
     final db = FakeFirebaseFirestore();
 
     final expectedEmitOrder = [
@@ -1880,7 +1881,11 @@ void main() {
     ];
 
     expect(
-      db.collection('docs').where('age', isLessThan: 30).snapshots().map((event) {
+      db
+          .collection('docs')
+          .where('age', isLessThan: 30)
+          .snapshots()
+          .map((event) {
         return event.docChanges.map((e) => e.type).toList();
       }),
       emitsInOrder(expectedEmitOrder),

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1869,4 +1869,38 @@ void main() {
       },
     });
   });
+
+  test('Should properly emit document type change on batch async save', () async {
+    final db = FakeFirebaseFirestore();
+
+    final expectedEmitOrder = [
+      [],
+      [DocumentChangeType.added, DocumentChangeType.added],
+      [DocumentChangeType.removed],
+    ];
+
+    expect(
+      db.collection('docs').where('age', isLessThan: 30).snapshots().map((event) {
+        return event.docChanges.map((e) => e.type).toList();
+      }),
+      emitsInOrder(expectedEmitOrder),
+    );
+
+    final op1 = db.collection('docs').doc('1').set(<String, dynamic>{
+      'name': 'Norman',
+      'age': 28,
+    });
+
+    final op2 = db.collection('docs').doc('2').set(<String, dynamic>{
+      'name': 'Peter',
+      'age': 19,
+    });
+
+    /// Parallel save
+    await Future.wait([op1, op2]);
+
+    await db.collection('docs').doc('1').set(<String, dynamic>{
+      'age': 36,
+    }, SetOptions(merge: true));
+  });
 }


### PR DESCRIPTION
Changes:
- Fixed the wrong docs change state (missing change info) on the snapshots when docs are saved in parallel

