### PR TITLE
support firing multiple removals when done in parallel

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -52,6 +52,10 @@ class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
     }
   }
 
+  Map<String, dynamic>? rawData() {
+    return _rawDocument;
+  }
+
   @override
   bool get exists => _exists;
 

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -1,8 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/src/mock_document_snapshot.dart';
 
 // ignore: subtype_of_sealed_class
 /// Wraps a DocumentSnapshot. The only difference with a DocumentSnapshot is
 /// that it exists by definition.
+/// TODO: check if MockQueryDocumentSnapshot could extend MockDocumentSnapshot.
 class MockQueryDocumentSnapshot<T extends Object?>
     implements QueryDocumentSnapshot<T> {
   final DocumentSnapshot<T> snapshot;
@@ -14,6 +16,13 @@ class MockQueryDocumentSnapshot<T extends Object?>
   @override
   T data() {
     return snapshot.data()!;
+  }
+
+  Map<String, dynamic>? rawData() {
+    if (snapshot is MockQueryDocumentSnapshot) {
+      return (snapshot as MockQueryDocumentSnapshot).rawData();
+    }
+    return (snapshot as MockDocumentSnapshot).rawData();
   }
 
   @override

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1877,6 +1877,7 @@ void main() {
     final expectedEmitOrder = [
       [],
       [DocumentChangeType.added, DocumentChangeType.added],
+      [DocumentChangeType.modified, DocumentChangeType.modified],
       [DocumentChangeType.removed, DocumentChangeType.removed],
     ];
 
@@ -1901,16 +1902,25 @@ void main() {
       'age': 19,
     });
 
-    /// Parallel save
+    /// Parallel save.
     await Future.wait([op1, op2]);
 
-    // Remove in parallel.
+    /// Parallel modification.
     final op3 = db.collection('docs').doc('1').set(<String, dynamic>{
-      'age': 36,
+      'age': 29,
     }, SetOptions(merge: true));
     final op4 = db.collection('docs').doc('2').set(<String, dynamic>{
-      'age': 40,
+      'age': 20,
     }, SetOptions(merge: true));
     await Future.wait([op3, op4]);
+
+    // Parallel deletion.
+    final op5 = db.collection('docs').doc('1').set(<String, dynamic>{
+      'age': 36,
+    }, SetOptions(merge: true));
+    final op6 = db.collection('docs').doc('2').set(<String, dynamic>{
+      'age': 40,
+    }, SetOptions(merge: true));
+    await Future.wait([op5, op6]);
   });
 }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1877,7 +1877,7 @@ void main() {
     final expectedEmitOrder = [
       [],
       [DocumentChangeType.added, DocumentChangeType.added],
-      [DocumentChangeType.removed],
+      [DocumentChangeType.removed, DocumentChangeType.removed],
     ];
 
     expect(
@@ -1904,8 +1904,13 @@ void main() {
     /// Parallel save
     await Future.wait([op1, op2]);
 
-    await db.collection('docs').doc('1').set(<String, dynamic>{
+    // Remove in parallel.
+    final op3 = db.collection('docs').doc('1').set(<String, dynamic>{
       'age': 36,
     }, SetOptions(merge: true));
+    final op4 = db.collection('docs').doc('2').set(<String, dynamic>{
+      'age': 40,
+    }, SetOptions(merge: true));
+    await Future.wait([op3, op4]);
   });
 }


### PR DESCRIPTION
#312 supported the case when two documents are added in parallel and we want to fire an event that includes both additions. This PR supports any parallel modification, such as when two documents are removed or modified in parallel.