### PR TITLE
Bumped rxdart version to ^0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.3
+
+Upgraded rxdart to ^0.28.0
+
 ## 3.0.2
 
 - Support including multiple `docChanges` when documents are added in parallel. Thank you [KholmatovS](https://github.com/KholmatovS)! [PR-312](https://github.com/atn832/fake_cloud_firestore/pull/312).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fake_cloud_firestore
 description: Previously known as cloud_firestore_mocks. Fake implementation of Cloud Firestore. Use this package to unit test apps that use Cloud Firestore.
-version: 3.0.2
+version: 3.0.3
 homepage: https://www.wafrat.com
 repository: https://github.com/atn832/fake_cloud_firestore
 
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.14.13
   plugin_platform_interface: ^2.0.0
   quiver: ^3.0.0
-  rxdart: ^0.27.1
+  rxdart: ^0.28.0
   mock_exceptions: ^0.8.2
   fake_firebase_security_rules: ^0.5.2
   rx: ^0.4.0


### PR DESCRIPTION
Hey! Thanks for this useful plugin!

I took the chance to bump rxdart to ^0.28.0 as many new libraries target this specific version.

Fixes #315 