### PR TITLE
fix dart format workflow: migrate from pedantic to flutter_lints

### DIFF
--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -11,7 +11,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: dart:latest
+      # Matches Flutter's current stable version (3.32.8) of Dart. https://docs.flutter.dev/install/archive#stable-channel
+      # TODO: hardcoding dart version be hard to keep up to date. Consider using subosito/flutter-action@v2 instead.
+      image: dart:3.8.1
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -16,4 +16,5 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+      - run: flutter pub get
       - run: dart format ./ --set-exit-if-changed

--- a/.github/workflows/dart-format.yaml
+++ b/.github/workflows/dart-format.yaml
@@ -10,11 +10,10 @@ on:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container:
-      # Matches Flutter's current stable version (3.32.8) of Dart. https://docs.flutter.dev/install/archive#stable-channel
-      # TODO: hardcoding dart version be hard to keep up to date. Consider using subosito/flutter-action@v2 instead.
-      image: dart:3.8.1
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
       - run: dart format ./ --set-exit-if-changed

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ example/android/local.properties
 **/ios/Pods
 **/ios/Podfile.lock
 **/ios/Runner.xcworkspace/xcuserdata/
+**/ios/Flutter/ephemeral
 
 android/.gradle/
 android/local.properties

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,6 @@
 # Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+# projects at Google.
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,6 @@
 # Defines a default set of lint rules enforced for
 # projects at Google.
-include: package:lints/recommended.yaml
+include: package:flutter_lints/flutter.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
     sdk: flutter
   test: ^1.15.2
   firebase_auth_mocks: ^0.15.0
-  lints: ^6.0.0
+  flutter_lints: ^6.0.0
 
 false_secrets:
   - google-services.json

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,9 +27,9 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.9.0
   test: ^1.15.2
   firebase_auth_mocks: ^0.15.0
+  lints: ^6.0.0
 
 false_secrets:
   - google-services.json


### PR DESCRIPTION
Looks like pedantic was discontinued 4 years ago. https://pub.dev/packages/pedantic

https://www.reddit.com/r/FlutterDev/comments/oc3hs8/pedantic_and_effective_dart_are_deprecated/#:~:text=Pedantic%20and%20Effective%20Dart%20are,relative%20package/reorder%20packages%20lints.

https://pub.dev/packages/flutter_lints